### PR TITLE
Reduced container image size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-FROM golang:1.21.5
+FROM golang:1.21.5 as build
 
 # Set destination for COPY
 WORKDIR /app
@@ -15,6 +15,10 @@ COPY *.go ./
 
 # Build
 RUN CGO_ENABLED=0 GOOS=linux go build -o /kromgo
+
+FROM gcr.io/distroless/base-debian12
+
+COPY --from=build /kromgo /kromgo
 
 # Optional:
 # To bind to a TCP port, runtime parameters must be supplied to the docker command.


### PR DESCRIPTION
This cuts image sizes down to about 30mb, and uses a base image with a minimal set of dependencies.

```
REPOSITORY   TAG       IMAGE ID       CREATED         SIZE
kromgo       latest    c9c36a2a827f   2 minutes ago   30MB
```