### PR TITLE
Set only required token permissions for container image publishing

### DIFF
--- a/.github/workflows/container-ci.yaml
+++ b/.github/workflows/container-ci.yaml
@@ -31,6 +31,10 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name == 'push'
 
+    permissions:
+      contents: read
+      packages: write
+
     steps:
       - name: Checkout Project
         uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4


### PR DESCRIPTION
Set only the contents read and packages write perms to reduce the scope of a compromised token. The permissions still need to be reset/minimized in the repo settings.