### PR TITLE
fix: incorrect byte mapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,8 @@ The `valueTemplate` field applies a [Go template](https://pkg.go.dev/text/templa
 | Function | Example input | Example output | Description |
 |---|---|---|---|
 | `simplifyDays` | `"1159"` | `3y64d` | Converts a day count to years and days |
-| `humanBytes` | `"1572864"` | `1.5MB` | Converts bytes to a human-readable size |
+| `humanBytes`   | `"1572864"` | `1.5MiB` | Bytes → human size with IEC binary units (KiB, MiB, GiB...)     |
+| `humanSIBytes` | `"1500000"` | `1.5MB`  | Bytes → human size with SI decimal units (÷1000, kB, MB, GB...) |
 | `humanDuration` | `"9000"` | `2h30m` | Converts seconds to a compact duration string |
 | `toUpper` | `"v1.31.0"` | `V1.31.0` | Uppercases the string |
 | `toLower` | `"HEALTHY"` | `healthy` | Lowercases the string |
@@ -134,7 +135,7 @@ metrics:
 
   - name: node_memory_used
     query: "node_memory_MemTotal_bytes - node_memory_MemAvailable_bytes"
-    valueTemplate: "{{ . | humanBytes }}"     # 1572864 → 1.5MB
+    valueTemplate: "{{ . | humanBytes }}"     # 1572864 → 1.5MiB
 ```
 
 ### Named templates

--- a/pkg/kromgo/formatting.go
+++ b/pkg/kromgo/formatting.go
@@ -10,13 +10,14 @@ import (
 )
 
 var templateFuncs = template.FuncMap{
-	"simplifyDays":       simplifyDays,
-	"humanBytes":         humanBytes,
-	"humanDuration":      humanDuration,
-	"humanizeThousands":  humanizeThousands,
-	"toUpper":            strings.ToUpper,
-	"toLower":            strings.ToLower,
-	"trim":               strings.TrimSpace,
+	"simplifyDays":      simplifyDays,
+	"humanBytes":        humanBytes,
+	"humanSIBytes":      humanSIBytes,
+	"humanDuration":     humanDuration,
+	"humanizeThousands": humanizeThousands,
+	"toUpper":           strings.ToUpper,
+	"toLower":           strings.ToLower,
+	"trim":              strings.TrimSpace,
 }
 
 // ApplyValueTemplate executes the given Go template string with value as the dot (.) data.
@@ -64,21 +65,36 @@ func simplifyDays(v interface{}) string {
 	return fmt.Sprintf("%dd", remaining)
 }
 
-// humanBytes converts a byte count into a human-readable size string.
-// For example, 1572864 becomes "1.5MB".
+// humanBytes converts a byte count into a human-readable size string using
+// IEC binary units (powers of 1024). For example, 1572864 becomes "1.5MiB".
+// For SI decimal units (powers of 1000, kB/MB/GB...) use humanSIBytes.
 func humanBytes(v interface{}) string {
 	f, err := toFloat(v)
 	if err != nil {
 		return fmt.Sprintf("%v", v)
 	}
-	units := []string{"B", "KB", "MB", "GB", "TB", "PB"}
+	return scaleBytes(f, 1024, []string{"B", "KiB", "MiB", "GiB", "TiB", "PiB"})
+}
+
+// humanSIBytes converts a byte count into a human-readable size string using
+// SI decimal units (powers of 1000). For example, 1500000 becomes "1.5MB".
+// For IEC binary units (powers of 1024, KiB/MiB/GiB...) use humanBytes.
+func humanSIBytes(v interface{}) string {
+	f, err := toFloat(v)
+	if err != nil {
+		return fmt.Sprintf("%v", v)
+	}
+	return scaleBytes(f, 1000, []string{"B", "kB", "MB", "GB", "TB", "PB"})
+}
+
+func scaleBytes(f float64, base float64, units []string) string {
 	i := 0
-	for f >= 1024 && i < len(units)-1 {
-		f /= 1024
+	for f >= base && i < len(units)-1 {
+		f /= base
 		i++
 	}
 	if i == 0 {
-		return fmt.Sprintf("%dB", int(math.Round(f)))
+		return fmt.Sprintf("%d%s", int(math.Round(f)), units[0])
 	}
 	return fmt.Sprintf("%.1f%s", f, units[i])
 }

--- a/pkg/kromgo/formatting_test.go
+++ b/pkg/kromgo/formatting_test.go
@@ -30,24 +30,51 @@ func TestSimplifyDays_InvalidInput(t *testing.T) {
 	assert.Equal(t, "notanumber", simplifyDays("notanumber"))
 }
 
-func TestHumanBytes_Bytes(t *testing.T) {
-	assert.Equal(t, "512B", humanBytes("512"))
+func TestHumanBytes(t *testing.T) {
+	tests := []struct {
+		name  string
+		input interface{}
+		want  string
+	}{
+		{"zero", "0", "0B"},
+		{"sub-kibibyte-string", "512", "512B"},
+		{"below-kibibyte-boundary", "1000", "1000B"},
+		{"exact-kibibyte-string", "1024", "1.0KiB"},
+		{"one-and-a-half-mib-string", "1572864", "1.5MiB"},
+		{"two-gib", "2147483648", "2.0GiB"},
+		{"above-pib-clamps", float64(2e18), "1776.4PiB"},
+		{"int-input", int(1024), "1.0KiB"},
+		{"float64-input", float64(1572864), "1.5MiB"},
+		{"invalid-input", "not-a-number", "not-a-number"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, humanBytes(tt.input))
+		})
+	}
 }
 
-func TestHumanBytes_Kilobytes(t *testing.T) {
-	assert.Equal(t, "1.0KB", humanBytes("1024"))
-}
-
-func TestHumanBytes_Megabytes(t *testing.T) {
-	assert.Equal(t, "1.5MB", humanBytes("1572864"))
-}
-
-func TestHumanBytes_Gigabytes(t *testing.T) {
-	assert.Equal(t, "2.0GB", humanBytes("2147483648"))
-}
-
-func TestHumanBytes_InvalidInput(t *testing.T) {
-	assert.Equal(t, "notanumber", humanBytes("notanumber"))
+func TestHumanSIBytes(t *testing.T) {
+	tests := []struct {
+		name  string
+		input interface{}
+		want  string
+	}{
+		{"zero", "0", "0B"},
+		{"sub-kilobyte-string", "512", "512B"},
+		{"exact-kilobyte-boundary", "1000", "1.0kB"},
+		{"kibibyte-in-si", "1024", "1.0kB"},
+		{"one-and-a-half-mb-string", "1572864", "1.6MB"},
+		{"above-pb-clamps", float64(2e18), "2000.0PB"},
+		{"int-input", int(1000), "1.0kB"},
+		{"float64-input", float64(1572864), "1.6MB"},
+		{"invalid-input", "not-a-number", "not-a-number"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, humanSIBytes(tt.input))
+		})
+	}
 }
 
 func TestHumanDuration_SecondsOnly(t *testing.T) {
@@ -116,6 +143,12 @@ func TestApplyValueTemplate_SimplifyDays(t *testing.T) {
 
 func TestApplyValueTemplate_HumanBytes(t *testing.T) {
 	result, err := ApplyValueTemplate("{{ . | humanBytes }}", "1572864")
+	assert.NoError(t, err)
+	assert.Equal(t, "1.5MiB", result)
+}
+
+func TestApplyValueTemplate_HumanSIBytes(t *testing.T) {
+	result, err := ApplyValueTemplate("{{ . | humanSIBytes }}", "1500000")
 	assert.NoError(t, err)
 	assert.Equal(t, "1.5MB", result)
 }


### PR DESCRIPTION
Breaking change: humanBytes output labels corrected to IEC standard

humanBytes was dividing by 1024 but labelling results with decimal-convention suffixes (KB, MB, GB…), which is incorrect per IEC 80000-13. This PR corrects the labels to the proper IEC binary suffixes (KiB, MiB, GiB, TiB, PiB). Concretely, a value of 1572864 that previously rendered as 1.5MB now renders as 1.5MiB. Any dashboard label, alert threshold text, or downstream parser that matched the old MB/GB-style strings will need to be updated. A new sibling function humanSIBytes is also added for cases where true SI decimal units (÷1000, kB/MB/GB) are wanted.