### PR TITLE
feat: add range query type with configurable window and offset

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,8 @@ Each entry under `metrics:` defines one queryable endpoint at `/{name}`.
 |---|---|---|
 | `name` | yes | URL path segment — `node_cpu_usage` → `GET /node_cpu_usage` |
 | `query` | yes | PromQL expression, must return a single scalar or vector value |
+| `type` | no | How the value is fetched: `instant` (default) or `range` — see [Query Types](#query-types) |
+| `range` | no | Window/step/reduction for `type: range` — see [Query Types](#query-types) |
 | `title` | no | Display label in badge/endpoint responses (defaults to `name`) |
 | `label` | no | Extract value from this metric label instead of the sample value |
 | `prefix` | no | String prepended to the value in the response (e.g. `v`) |
@@ -108,6 +110,42 @@ metrics:
 ```
 
 Supported color names: `blue`, `brightgreen`, `green`, `grey`, `lightgrey`, `orange`, `red`, `yellow`, `yellowgreen`, `success`, `important`, `critical`, `informational`, `inactive`. Hex values (e.g. `#e05d44`) are also accepted.
+
+## Query Types
+
+The `type` field selects how a metric's value is fetched from Prometheus. It is independent of the response `format` (`json`, `badge`, `raw`).
+
+| Type | Description |
+|---|---|
+| `instant` (default) | Evaluates `query` at the current time, like the Prometheus `/query` endpoint. This is the original behavior; omit `type` to keep it. |
+| `range` | Evaluates `query` over a time window and reduces each series to a single value. |
+
+### Range queries
+
+When `type: range`, the `range` block controls the window and reduction. The evaluated window is `end = now - offset`, `start = end - last`:
+
+| Field | Required | Description |
+|---|---|---|
+| `last` | yes | Window length, e.g. `7d`. Supports `s`, `m`, `h`, `d`, `y` (combinable: `1y30d`). |
+| `step` | yes | Resolution of the range query, e.g. `1h`. |
+| `offset` | no | Shift the whole window back in time, e.g. `7d`. Defaults to `0` (window ends now). |
+| `reduce` | no | How to collapse each series to one value: `last` (default), `first`, `avg`, `min`, `max`, `sum`. |
+
+```yaml
+metrics:
+  # Average CPU usage over the previous week (14d ago .. 7d ago)
+  - name: cpu_prev_week_avg
+    type: range
+    query: "cluster:node_cpu:ratio_rate5m * 100"
+    range:
+      last: "7d"      # window length
+      offset: "7d"    # shift back 7d → covers 14d ago .. 7d ago
+      step: "1h"
+      reduce: avg
+    suffix: "%"
+```
+
+The reduced value flows through `label`, `colors`, `prefix`/`suffix`, and `valueTemplate` exactly like an instant query. The `format=history` and `format=chart` renderers are separate and always query the full window of `query`.
 
 ## Value Templates
 

--- a/cmd/kromgo/init/configuration/configuration.go
+++ b/cmd/kromgo/init/configuration/configuration.go
@@ -72,16 +72,16 @@ type ServerConfig struct {
 
 // KromgoConfig struct for configuration environmental variables
 type KromgoConfig struct {
-	Prometheus string            `yaml:"prometheus,omitempty" json:"prometheus,omitempty"`
-	Metrics    []Metric          `yaml:"metrics" json:"metrics"`
-	Badge      Badge             `yaml:"badge,omitempty" json:"badge,omitempty"`
+	Prometheus string   `yaml:"prometheus,omitempty" json:"prometheus,omitempty"`
+	Metrics    []Metric `yaml:"metrics" json:"metrics"`
+	Badge      Badge    `yaml:"badge,omitempty" json:"badge,omitempty"`
 	// Named Go template snippets that can be referenced by name in a metric's valueTemplate field.
-	Templates  map[string]string `yaml:"templates,omitempty" json:"templates,omitempty"`
+	Templates map[string]string `yaml:"templates,omitempty" json:"templates,omitempty"`
 	// HideAll sets the default visibility for all metrics on the index page.
 	// Defaults to true (all hidden) when not specified.
-	HideAll    *bool             `yaml:"hideAll,omitempty" json:"hideAll,omitempty"`
+	HideAll *bool `yaml:"hideAll,omitempty" json:"hideAll,omitempty"`
 	// History controls access to format=history requests.
-	History    HistoryConfig     `yaml:"history,omitempty" json:"history,omitempty"`
+	History HistoryConfig `yaml:"history,omitempty" json:"history,omitempty"`
 }
 
 type HistoryConfig struct {
@@ -98,6 +98,11 @@ type Metric struct {
 	Title string `yaml:"title,omitempty" json:"title,omitempty"`
 	// The prometheus query to run.
 	Query string `yaml:"query" json:"query"`
+	// QueryType selects how the metric value is fetched: "instant" (default) or "range".
+	// A "range" query is evaluated over a window and reduced to a single value (see Range).
+	QueryType string `yaml:"type,omitempty" json:"type,omitempty"`
+	// Range configures the window, step, and reduction used when QueryType == "range".
+	Range *RangeConfig `yaml:"range,omitempty" json:"range,omitempty"`
 	// Fetch the value from this label in the prometheus query.
 	Label string `yaml:"label,omitempty" json:"label,omitempty"`
 	// Prefix the result of the query with this.
@@ -116,6 +121,26 @@ type Metric struct {
 	// History controls format=history access for this metric.
 	// If nil, the global history settings are used.
 	History *MetricHistoryConfig `yaml:"history,omitempty" json:"history,omitempty"`
+}
+
+// Query types accepted in a Metric's QueryType field.
+const (
+	QueryTypeInstant = "instant"
+	QueryTypeRange   = "range"
+)
+
+// RangeConfig configures a range query that is reduced to a single value.
+// The evaluated window is: end = now - Offset, start = end - Last.
+type RangeConfig struct {
+	// Last is the length of the window, e.g. "7d". Required for range queries.
+	Last string `yaml:"last,omitempty" json:"last,omitempty"`
+	// Offset shifts the whole window back in time, e.g. "7d". Defaults to "0" (window ends now).
+	// Last "7d" with Offset "7d" covers 14d ago .. 7d ago.
+	Offset string `yaml:"offset,omitempty" json:"offset,omitempty"`
+	// Step is the resolution of the range query, e.g. "1h". Required for range queries.
+	Step string `yaml:"step,omitempty" json:"step,omitempty"`
+	// Reduce collapses each series to a single value: last|first|avg|min|max|sum. Defaults to "last".
+	Reduce string `yaml:"reduce,omitempty" json:"reduce,omitempty"`
 }
 
 type MetricHistoryConfig struct {
@@ -165,6 +190,11 @@ func Init(configPath string) KromgoConfig {
 		os.Exit(1)
 	}
 
+	if err := validateQueryTypes(config); err != nil {
+		log.Error("invalid query configuration", zap.Error(err))
+		os.Exit(1)
+	}
+
 	ProcessedMetrics = preprocess(config.Metrics)
 	return config
 }
@@ -180,6 +210,55 @@ func validateHistoryDurations(config KromgoConfig) error {
 			if _, err := ParseDuration(m.History.MaxDuration); err != nil {
 				return fmt.Errorf("metric %q history.maxDuration: %w", m.Name, err)
 			}
+		}
+	}
+	return nil
+}
+
+// validReduceFuncs is the set of reductions allowed in RangeConfig.Reduce.
+var validReduceFuncs = map[string]bool{
+	"last": true, "first": true, "avg": true, "min": true, "max": true, "sum": true,
+}
+
+func validateQueryTypes(config KromgoConfig) error {
+	for _, m := range config.Metrics {
+		switch m.QueryType {
+		case "", QueryTypeInstant:
+			if m.Range != nil {
+				return fmt.Errorf("metric %q: range is only valid when type is %q", m.Name, QueryTypeRange)
+			}
+		case QueryTypeRange:
+			if m.Range == nil {
+				return fmt.Errorf("metric %q: type %q requires a range block", m.Name, QueryTypeRange)
+			}
+			d, err := ParseDuration(m.Range.Last)
+			if err != nil {
+				return fmt.Errorf("metric %q range.last: %w", m.Name, err)
+			}
+			if d <= 0 {
+				return fmt.Errorf("metric %q range.last must be a positive duration", m.Name)
+			}
+			step, err := ParseDuration(m.Range.Step)
+			if err != nil {
+				return fmt.Errorf("metric %q range.step: %w", m.Name, err)
+			}
+			if step <= 0 {
+				return fmt.Errorf("metric %q range.step must be a positive duration", m.Name)
+			}
+			if m.Range.Offset != "" {
+				off, err := ParseDuration(m.Range.Offset)
+				if err != nil {
+					return fmt.Errorf("metric %q range.offset: %w", m.Name, err)
+				}
+				if off < 0 {
+					return fmt.Errorf("metric %q range.offset must not be negative", m.Name)
+				}
+			}
+			if m.Range.Reduce != "" && !validReduceFuncs[m.Range.Reduce] {
+				return fmt.Errorf("metric %q range.reduce %q is not one of last|first|avg|min|max|sum", m.Name, m.Range.Reduce)
+			}
+		default:
+			return fmt.Errorf("metric %q: unknown type %q (expected %q or %q)", m.Name, m.QueryType, QueryTypeInstant, QueryTypeRange)
 		}
 	}
 	return nil

--- a/cmd/kromgo/init/configuration/query_test.go
+++ b/cmd/kromgo/init/configuration/query_test.go
@@ -1,0 +1,68 @@
+package configuration
+
+import "testing"
+
+func TestValidateQueryTypes(t *testing.T) {
+	cases := []struct {
+		name    string
+		metric  Metric
+		wantErr bool
+	}{
+		{
+			name:   "instant default",
+			metric: Metric{Name: "a", Query: "up"},
+		},
+		{
+			name:   "explicit instant",
+			metric: Metric{Name: "a", Query: "up", QueryType: QueryTypeInstant},
+		},
+		{
+			name:    "instant with range block",
+			metric:  Metric{Name: "a", Query: "up", Range: &RangeConfig{Last: "7d", Step: "1h"}},
+			wantErr: true,
+		},
+		{
+			name:   "valid range",
+			metric: Metric{Name: "a", Query: "up", QueryType: QueryTypeRange, Range: &RangeConfig{Last: "7d", Offset: "7d", Step: "1h", Reduce: "avg"}},
+		},
+		{
+			name:    "range missing block",
+			metric:  Metric{Name: "a", Query: "up", QueryType: QueryTypeRange},
+			wantErr: true,
+		},
+		{
+			name:    "range missing last",
+			metric:  Metric{Name: "a", Query: "up", QueryType: QueryTypeRange, Range: &RangeConfig{Step: "1h"}},
+			wantErr: true,
+		},
+		{
+			name:    "range missing step",
+			metric:  Metric{Name: "a", Query: "up", QueryType: QueryTypeRange, Range: &RangeConfig{Last: "7d"}},
+			wantErr: true,
+		},
+		{
+			name:    "range bad reduce",
+			metric:  Metric{Name: "a", Query: "up", QueryType: QueryTypeRange, Range: &RangeConfig{Last: "7d", Step: "1h", Reduce: "median"}},
+			wantErr: true,
+		},
+		{
+			name:    "range bad offset",
+			metric:  Metric{Name: "a", Query: "up", QueryType: QueryTypeRange, Range: &RangeConfig{Last: "7d", Step: "1h", Offset: "nope"}},
+			wantErr: true,
+		},
+		{
+			name:    "unknown type",
+			metric:  Metric{Name: "a", Query: "up", QueryType: "series"},
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validateQueryTypes(KromgoConfig{Metrics: []Metric{tc.metric}})
+			if (err != nil) != tc.wantErr {
+				t.Errorf("validateQueryTypes() error = %v, wantErr %v", err, tc.wantErr)
+			}
+		})
+	}
+}

--- a/config.schema.json
+++ b/config.schema.json
@@ -78,6 +78,12 @@
         "query": {
           "type": "string"
         },
+        "type": {
+          "type": "string"
+        },
+        "range": {
+          "$ref": "#/$defs/RangeConfig"
+        },
         "label": {
           "type": "string"
         },
@@ -138,6 +144,24 @@
           "type": "boolean"
         },
         "maxDuration": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "RangeConfig": {
+      "properties": {
+        "last": {
+          "type": "string"
+        },
+        "offset": {
+          "type": "string"
+        },
+        "step": {
+          "type": "string"
+        },
+        "reduce": {
           "type": "string"
         }
       },

--- a/config.yaml.example
+++ b/config.yaml.example
@@ -69,6 +69,23 @@ metrics:
     valueTemplate: "clusterAge"              # resolved via templates map below
   - name: node_uptime
     query: "time() - node_boot_time_seconds"
+
+  # type: range - evaluate the query over a window and reduce it to a single value.
+  # The window is: end = now - offset, start = end - last.
+  # Example: average CPU usage over the previous week (14d ago .. 7d ago).
+  - name: cpu_prev_week_avg
+    type: range
+    query: "cluster:node_cpu:ratio_rate5m * 100"
+    range:
+      last: "7d"      # window length (s, m, h, d, y — combinable: "1y30d")
+      offset: "7d"    # shift the window back; omit for a window ending now
+      step: "1h"      # resolution of the range query
+      reduce: avg     # last | first | avg | min | max | sum (default: last)
+    suffix: "%"
+    colors:
+      - { color: "green", min: 0, max: 35 }
+      - { color: "orange", min: 36, max: 75 }
+      - { color: "red", min: 76, max: 1000 }
 # Named template snippets - reference these by key in any metric's valueTemplate field
 templates:
   clusterAge: "{{ . | simplifyDays }}"   # 1159 → "3y64d"

--- a/pkg/kromgo/kromgo.go
+++ b/pkg/kromgo/kromgo.go
@@ -9,14 +9,11 @@ import (
 	"strconv"
 	"strings"
 	"sync"
-	"time"
 
 	"github.com/essentialkaos/go-badge"
 	"github.com/go-chi/chi/v5"
 	"github.com/kashalls/kromgo/cmd/kromgo/init/configuration"
 	"github.com/kashalls/kromgo/cmd/kromgo/init/log"
-	"github.com/kashalls/kromgo/cmd/kromgo/init/prometheus"
-	"github.com/prometheus/common/model"
 	"go.uber.org/zap"
 )
 
@@ -60,7 +57,7 @@ func NewKromgoHandler(config configuration.KromgoConfig) (*KromgoHandler, error)
 func (h *KromgoHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	requestMetric := chi.URLParam(r, "metric")
 	if requestMetric == "" {
-		HandleError(w,r, requestMetric, "A valid metric name must be passed /{metric}", http.StatusBadRequest)
+		HandleError(w, r, requestMetric, "A valid metric name must be passed /{metric}", http.StatusBadRequest)
 		return
 	}
 	if requestMetric == "query" {
@@ -75,7 +72,6 @@ func (h *KromgoHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	defer func() {
 		requestsTotal.WithLabelValues(requestMetric, requestFormat).Inc()
 	}()
-
 
 	metric, exists := configuration.ProcessedMetrics[requestMetric]
 
@@ -95,9 +91,9 @@ func (h *KromgoHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Run the Prometheus query
+	// Run the Prometheus query (instant or range, depending on metric.QueryType).
 	// potentially utilize withlimit or withtimeout
-	promResult, warnings, err := prometheus.Papi.Query(r.Context(), metric.Query, time.Now())
+	prometheusData, warnings, err := executeMetricQuery(r.Context(), metric)
 	if err != nil {
 		requestLog(r).With(zap.Error(err)).Error("error executing metric query")
 		w.WriteHeader(http.StatusInternalServerError)
@@ -109,7 +105,7 @@ func (h *KromgoHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			requestLog(r).With(zap.String("warning", warning)).Warn("encountered warnings while executing metric query")
 		}
 	}
-	jsonResult, err := json.Marshal(promResult)
+	jsonResult, err := json.Marshal(prometheusData)
 	requestLog(r).With(zap.String("result", string(jsonResult))).Debug("query result")
 	if err != nil {
 		requestLog(r).With(zap.Error(err)).Error("could not convert query result to json")
@@ -129,11 +125,10 @@ func (h *KromgoHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	prometheusData := promResult.(model.Vector)
 	log.Debug("prometheus returned data", zap.Any("data", prometheusData))
 
 	var colorConfig configuration.MetricColor
-	var response string 
+	var response string
 	if len(prometheusData) > 0 {
 		resultValue := float64(prometheusData[0].Value)
 		colorConfig = GetColorConfig(metric.Colors, resultValue)

--- a/pkg/kromgo/query.go
+++ b/pkg/kromgo/query.go
@@ -1,0 +1,124 @@
+package kromgo
+
+import (
+	"context"
+	"fmt"
+	"math"
+	"time"
+
+	"github.com/kashalls/kromgo/cmd/kromgo/init/configuration"
+	"github.com/kashalls/kromgo/cmd/kromgo/init/prometheus"
+	v1 "github.com/prometheus/client_golang/api/prometheus/v1"
+	"github.com/prometheus/common/model"
+)
+
+// executeMetricQuery fetches a metric's value from Prometheus according to its
+// query type. Both instant and range queries normalize to a model.Vector so the
+// downstream rendering pipeline (labels, colors, templates, badge/json) is shared.
+func executeMetricQuery(ctx context.Context, metric configuration.Metric) (model.Vector, v1.Warnings, error) {
+	switch metric.QueryType {
+	case configuration.QueryTypeRange:
+		return executeRangeQuery(ctx, metric)
+	default:
+		result, warnings, err := prometheus.Papi.Query(ctx, metric.Query, time.Now())
+		if err != nil {
+			return nil, warnings, err
+		}
+		vector, ok := result.(model.Vector)
+		if !ok {
+			return nil, warnings, fmt.Errorf("instant query did not return a vector")
+		}
+		return vector, warnings, nil
+	}
+}
+
+// executeRangeQuery runs a range query over the configured window and reduces
+// each series to a single sample, returning a synthetic vector.
+func executeRangeQuery(ctx context.Context, metric configuration.Metric) (model.Vector, v1.Warnings, error) {
+	start, end, step := rangeWindow(metric.Range, time.Now())
+
+	result, warnings, err := prometheus.Papi.QueryRange(ctx, metric.Query, v1.Range{
+		Start: start,
+		End:   end,
+		Step:  step,
+	})
+	if err != nil {
+		return nil, warnings, err
+	}
+
+	matrix, ok := result.(model.Matrix)
+	if !ok {
+		return nil, warnings, fmt.Errorf("range query did not return a matrix")
+	}
+
+	reduce := metric.Range.Reduce
+	if reduce == "" {
+		reduce = "last"
+	}
+
+	vector := make(model.Vector, 0, len(matrix))
+	for _, stream := range matrix {
+		if len(stream.Values) == 0 {
+			continue
+		}
+		vector = append(vector, &model.Sample{
+			Metric:    stream.Metric,
+			Value:     reduceSamples(stream.Values, reduce),
+			Timestamp: stream.Values[len(stream.Values)-1].Timestamp,
+		})
+	}
+	return vector, warnings, nil
+}
+
+// rangeWindow computes the query window from a RangeConfig relative to now.
+// Durations are validated at config load, so parsing cannot fail here.
+func rangeWindow(rc *configuration.RangeConfig, now time.Time) (start, end time.Time, step time.Duration) {
+	last, _ := configuration.ParseDuration(rc.Last)
+	step, _ = configuration.ParseDuration(rc.Step)
+
+	var offset time.Duration
+	if rc.Offset != "" {
+		offset, _ = configuration.ParseDuration(rc.Offset)
+	}
+
+	end = now.Add(-offset)
+	start = end.Add(-last)
+	return start, end, step
+}
+
+// reduceSamples collapses a series of samples into a single value.
+func reduceSamples(values []model.SamplePair, fn string) model.SampleValue {
+	if len(values) == 0 {
+		return 0
+	}
+	switch fn {
+	case "first":
+		return values[0].Value
+	case "sum":
+		var sum float64
+		for _, v := range values {
+			sum += float64(v.Value)
+		}
+		return model.SampleValue(sum)
+	case "avg":
+		var sum float64
+		for _, v := range values {
+			sum += float64(v.Value)
+		}
+		return model.SampleValue(sum / float64(len(values)))
+	case "min":
+		m := math.Inf(1)
+		for _, v := range values {
+			m = math.Min(m, float64(v.Value))
+		}
+		return model.SampleValue(m)
+	case "max":
+		m := math.Inf(-1)
+		for _, v := range values {
+			m = math.Max(m, float64(v.Value))
+		}
+		return model.SampleValue(m)
+	default: // "last"
+		return values[len(values)-1].Value
+	}
+}

--- a/pkg/kromgo/query_test.go
+++ b/pkg/kromgo/query_test.go
@@ -1,0 +1,72 @@
+package kromgo
+
+import (
+	"testing"
+	"time"
+
+	"github.com/kashalls/kromgo/cmd/kromgo/init/configuration"
+	"github.com/prometheus/common/model"
+)
+
+func samples(vals ...float64) []model.SamplePair {
+	out := make([]model.SamplePair, len(vals))
+	for i, v := range vals {
+		out[i] = model.SamplePair{Timestamp: model.Time(i * 1000), Value: model.SampleValue(v)}
+	}
+	return out
+}
+
+func TestReduceSamples(t *testing.T) {
+	values := samples(2, 5, 1, 4)
+	cases := map[string]float64{
+		"last":  4,
+		"first": 2,
+		"sum":   12,
+		"avg":   3,
+		"min":   1,
+		"max":   5,
+		"":      4, // defaults to last
+	}
+	for fn, want := range cases {
+		if got := float64(reduceSamples(values, fn)); got != want {
+			t.Errorf("reduce %q = %v, want %v", fn, got, want)
+		}
+	}
+}
+
+func TestReduceSamples_Empty(t *testing.T) {
+	if got := reduceSamples(nil, "avg"); got != 0 {
+		t.Errorf("reduce of empty series = %v, want 0", got)
+	}
+}
+
+func TestRangeWindow_NoOffset(t *testing.T) {
+	now := time.Date(2026, 5, 30, 12, 0, 0, 0, time.UTC)
+	rc := &configuration.RangeConfig{Last: "7d", Step: "1h"}
+
+	start, end, step := rangeWindow(rc, now)
+	if !end.Equal(now) {
+		t.Errorf("end = %v, want now %v", end, now)
+	}
+	if !start.Equal(now.Add(-7 * 24 * time.Hour)) {
+		t.Errorf("start = %v, want now-7d", start)
+	}
+	if step != time.Hour {
+		t.Errorf("step = %v, want 1h", step)
+	}
+}
+
+func TestRangeWindow_WithOffset(t *testing.T) {
+	now := time.Date(2026, 5, 30, 12, 0, 0, 0, time.UTC)
+	rc := &configuration.RangeConfig{Last: "7d", Offset: "7d", Step: "1h"}
+
+	start, end, _ := rangeWindow(rc, now)
+	wantEnd := now.Add(-7 * 24 * time.Hour)    // 7d ago
+	wantStart := now.Add(-14 * 24 * time.Hour) // 14d ago
+	if !end.Equal(wantEnd) {
+		t.Errorf("end = %v, want 7d ago %v", end, wantEnd)
+	}
+	if !start.Equal(wantStart) {
+		t.Errorf("start = %v, want 14d ago %v", start, wantStart)
+	}
+}


### PR DESCRIPTION
## Summary

Adds a `range` query type so a metric's value can be computed from a Prometheus range query over a time window and reduced to a single value, alongside the existing instant query.

Metrics gain an optional `type` field (`instant` default, or `range`) and a `range` block:

| Field | Description |
|---|---|
| `last` | Window length (e.g. `7d`) |
| `offset` | Shift the window back in time (e.g. `7d`); defaults to now |
| `step` | Resolution of the range query (e.g. `1h`) |
| `reduce` | Collapse each series to one value: `last` (default), `first`, `avg`, `min`, `max`, `sum` |

The window is `end = now - offset`, `start = end - last`, so `last: 7d` with `offset: 7d` covers **14d ago .. 7d ago**.

## Example

```yaml
metrics:
  - name: cpu_prev_week_avg
    type: range
    query: "cluster:node_cpu:ratio_rate5m * 100"
    range:
      last: "7d"
      offset: "7d"
      step: "1h"
      reduce: avg
    suffix: "%"
