### PR TITLE
refactor: reorganize kromgo package and clean up tests

### DIFF
--- a/internal/config/duration.go
+++ b/internal/config/duration.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"regexp"
 	"strconv"
-	"strings"
 	"time"
 )
 
@@ -25,16 +24,17 @@ func ParseDuration(s string) (time.Duration, error) {
 	}
 
 	var total time.Duration
-	remaining := s
 	for _, m := range durationUnitRe.FindAllStringSubmatch(s, -1) {
 		n, err := strconv.ParseFloat(m[1], 64)
 		if err != nil {
 			return 0, fmt.Errorf("invalid duration %q", s)
 		}
 		total += time.Duration(float64(durationMultipliers[m[2]]) * n)
-		remaining = strings.Replace(remaining, m[0], "", 1)
 	}
 
+	// Strip the custom-unit components in one pass; whatever remains is handed to
+	// the stdlib parser (e.g. "7d12h" -> "12h").
+	remaining := durationUnitRe.ReplaceAllString(s, "")
 	if remaining != "" {
 		d, err := time.ParseDuration(remaining)
 		if err != nil {

--- a/internal/config/duration_test.go
+++ b/internal/config/duration_test.go
@@ -3,136 +3,105 @@ package config
 import (
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
-func TestParseDuration_Days(t *testing.T) {
-	d, err := ParseDuration("7d")
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
+func TestParseDuration(t *testing.T) {
+	cases := []struct {
+		name    string
+		in      string
+		want    time.Duration
+		wantErr bool
+	}{
+		{"days", "7d", 7 * 24 * time.Hour, false},
+		{"years", "1y", 365 * 24 * time.Hour, false},
+		{"combined years and days", "1y30d", (365 + 30) * 24 * time.Hour, false},
+		{"days and hours", "1d12h", 36 * time.Hour, false},
+		{"minutes", "30m", 30 * time.Minute, false},
+		{"hours", "6h", 6 * time.Hour, false},
+		{"seconds", "90s", 90 * time.Second, false},
+		{"milliseconds", "500ms", 500 * time.Millisecond, false},
+		{"zero", "0", 0, false},
+		{"empty", "", 0, true},
+		{"invalid", "invalid", 0, true},
 	}
-	if d != 7*24*time.Hour {
-		t.Errorf("expected 168h, got %v", d)
-	}
-}
-
-func TestParseDuration_Years(t *testing.T) {
-	d, err := ParseDuration("1y")
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if d != 365*24*time.Hour {
-		t.Errorf("expected 8760h, got %v", d)
-	}
-}
-
-func TestParseDuration_Combined(t *testing.T) {
-	d, err := ParseDuration("1y30d")
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if d != (365+30)*24*time.Hour {
-		t.Errorf("expected %v, got %v", (365+30)*24*time.Hour, d)
-	}
-}
-
-func TestParseDuration_DaysAndHours(t *testing.T) {
-	d, err := ParseDuration("1d12h")
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if d != 36*time.Hour {
-		t.Errorf("expected 36h, got %v", d)
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := ParseDuration(tc.in)
+			if tc.wantErr {
+				assert.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tc.want, got)
+		})
 	}
 }
 
-func TestParseDuration_StandardUnits(t *testing.T) {
-	cases := map[string]time.Duration{
-		"30m":   30 * time.Minute,
-		"6h":    6 * time.Hour,
-		"90s":   90 * time.Second,
-		"500ms": 500 * time.Millisecond,
-	}
-	for s, want := range cases {
-		d, err := ParseDuration(s)
-		if err != nil {
-			t.Errorf("%s: unexpected error: %v", s, err)
-			continue
-		}
-		if d != want {
-			t.Errorf("%s: expected %v, got %v", s, want, d)
-		}
-	}
-}
-
-func TestParseDuration_Zero(t *testing.T) {
-	d, err := ParseDuration("0")
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if d != 0 {
-		t.Errorf("expected 0, got %v", d)
-	}
-}
-
-func TestParseDuration_Invalid(t *testing.T) {
-	_, err := ParseDuration("invalid")
-	if err == nil {
-		t.Fatal("expected error for invalid duration")
-	}
-}
-
-func TestValidate_Valid(t *testing.T) {
-	cfg := KromgoConfig{
-		Defaults: Defaults{Timeseries: TimeseriesConfig{MaxDuration: "24h"}},
-		Metrics: []Metric{
-			{Name: "cpu", Timeseries: &MetricTimeseriesConfig{MaxDuration: "7d"}},
-			{Name: "mem"},
+func TestValidate_Durations(t *testing.T) {
+	cases := []struct {
+		name    string
+		cfg     KromgoConfig
+		wantErr bool
+	}{
+		{
+			"valid",
+			KromgoConfig{
+				Defaults: Defaults{Timeseries: TimeseriesConfig{MaxDuration: "24h"}},
+				Metrics: []Metric{
+					{Name: "cpu", Timeseries: &MetricTimeseriesConfig{MaxDuration: "7d"}},
+					{Name: "mem"},
+				},
+			},
+			false,
+		},
+		{
+			"invalid default maxDuration",
+			KromgoConfig{Defaults: Defaults{Timeseries: TimeseriesConfig{MaxDuration: "bogus"}}},
+			true,
+		},
+		{
+			"invalid metric maxDuration",
+			KromgoConfig{Metrics: []Metric{{Name: "cpu", Timeseries: &MetricTimeseriesConfig{MaxDuration: "not-a-duration"}}}},
+			true,
 		},
 	}
-	if err := cfg.validate(); err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-}
-
-func TestValidate_InvalidDefault(t *testing.T) {
-	cfg := KromgoConfig{
-		Defaults: Defaults{Timeseries: TimeseriesConfig{MaxDuration: "bogus"}},
-	}
-	if err := cfg.validate(); err == nil {
-		t.Fatal("expected error for invalid defaults.timeseries.maxDuration")
-	}
-}
-
-func TestValidate_InvalidMetric(t *testing.T) {
-	cfg := KromgoConfig{
-		Metrics: []Metric{
-			{Name: "cpu", Timeseries: &MetricTimeseriesConfig{MaxDuration: "not-a-duration"}},
-		},
-	}
-	if err := cfg.validate(); err == nil {
-		t.Fatal("expected error for invalid metric maxDuration")
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.cfg.validate()
+			if tc.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
 	}
 }
 
 func TestValidate_RangeType(t *testing.T) {
-	ok := KromgoConfig{Metrics: []Metric{
-		{Name: "ok", Type: TypeRange, Range: &RangeQuery{Last: "7d", Offset: "1d", Step: "1h", Reduce: ReduceAvg}},
-	}}
-	if err := ok.validate(); err != nil {
-		t.Fatalf("unexpected error: %v", err)
+	cases := []struct {
+		name    string
+		cfg     KromgoConfig
+		wantErr bool
+	}{
+		{"valid range", KromgoConfig{Metrics: []Metric{{Name: "ok", Type: TypeRange, Range: &RangeQuery{Last: "7d", Offset: "1d", Step: "1h", Reduce: ReduceAvg}}}}, false},
+		{"type range without range block", KromgoConfig{Metrics: []Metric{{Name: "no-range", Type: TypeRange}}}, true},
+		{"missing last", KromgoConfig{Metrics: []Metric{{Name: "no-last", Type: TypeRange, Range: &RangeQuery{Step: "1h"}}}}, true},
+		{"unknown reducer", KromgoConfig{Metrics: []Metric{{Name: "bad-reduce", Type: TypeRange, Range: &RangeQuery{Last: "7d", Reduce: "median"}}}}, true},
+		{"bad duration", KromgoConfig{Metrics: []Metric{{Name: "bad-dur", Type: TypeRange, Range: &RangeQuery{Last: "soon"}}}}, true},
+		{"range block on instant", KromgoConfig{Metrics: []Metric{{Name: "range-on-instant", Range: &RangeQuery{Last: "7d"}}}}, true},
+		{"unknown type", KromgoConfig{Metrics: []Metric{{Name: "bad-type", Type: "scalar"}}}, true},
 	}
-
-	bad := []KromgoConfig{
-		{Metrics: []Metric{{Name: "no-range", Type: TypeRange}}},                                // type range without range block
-		{Metrics: []Metric{{Name: "no-last", Type: TypeRange, Range: &RangeQuery{Step: "1h"}}}}, // missing last
-		{Metrics: []Metric{{Name: "bad-reduce", Type: TypeRange, Range: &RangeQuery{Last: "7d", Reduce: "median"}}}},
-		{Metrics: []Metric{{Name: "bad-dur", Type: TypeRange, Range: &RangeQuery{Last: "soon"}}}},
-		{Metrics: []Metric{{Name: "range-on-instant", Range: &RangeQuery{Last: "7d"}}}}, // range block without type: range
-		{Metrics: []Metric{{Name: "bad-type", Type: "scalar"}}},
-	}
-	for _, cfg := range bad {
-		if err := cfg.validate(); err == nil {
-			t.Errorf("expected validation error for %q", cfg.Metrics[0].Name)
-		}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.cfg.validate()
+			if tc.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
 	}
 }

--- a/internal/kromgo/chart.go
+++ b/internal/kromgo/chart.go
@@ -122,42 +122,38 @@ func renderSparkline(matrix model.Matrix, p chartParams) string {
 	fmt.Fprintf(&sb, `<svg xmlns="http://www.w3.org/2000/svg" width="%d" height="%d" viewBox="0 0 %d %d">`,
 		p.width, totalHeight, p.width, totalHeight)
 
+	type point struct{ x, y float64 }
 	for i, stream := range matrix {
 		// Prometheus can return NaN/Inf samples (counter resets, staleness gaps);
-		// they would poison min/max and emit NaN SVG coordinates, so skip them.
+		// they would poison min/max and emit NaN SVG coordinates, so skip them. A
+		// single pass collects each finite sample's x (from its original index, so
+		// skipped samples leave a gap) and raw value while tracking min/max; y is
+		// finalized below once the range is known.
+		n := len(stream.Values)
+		pts := make([]point, 0, n)
 		minVal := math.Inf(1)
 		maxVal := math.Inf(-1)
-		for _, pt := range stream.Values {
+		for j, pt := range stream.Values {
 			v := float64(pt.Value)
 			if math.IsNaN(v) || math.IsInf(v, 0) {
 				continue
 			}
 			minVal = min(minVal, v)
 			maxVal = max(maxVal, v)
+			pts = append(pts, point{x: pad + float64(j)/float64(max(n-1, 1))*w, y: v})
 		}
-		if math.IsInf(minVal, 1) {
+		if len(pts) == 0 {
 			continue // no finite samples to plot
 		}
 		valRange := maxVal - minVal
 		if valRange == 0 {
 			valRange = 1
 		}
-
-		n := len(stream.Values)
-		color := seriesColor(i, p.color)
-
-		type point struct{ x, y float64 }
-		pts := make([]point, 0, n)
-		for j, pt := range stream.Values {
-			v := float64(pt.Value)
-			if math.IsNaN(v) || math.IsInf(v, 0) {
-				continue
-			}
-			pts = append(pts, point{
-				x: pad + float64(j)/float64(max(n-1, 1))*w,
-				y: pad + (1-(v-minVal)/valRange)*h,
-			})
+		for k := range pts {
+			pts[k].y = pad + (1-(pts[k].y-minVal)/valRange)*h
 		}
+
+		color := seriesColor(i, p.color)
 
 		// Filled area under the line.
 		var area strings.Builder

--- a/internal/kromgo/chart_test.go
+++ b/internal/kromgo/chart_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/prometheus/common/model"
+	"github.com/stretchr/testify/assert"
 )
 
 func makeMatrix(series [][]float64) model.Matrix {
@@ -50,12 +51,8 @@ func TestRenderSparkline_Structure(t *testing.T) {
 		makeMatrix([][]float64{{10, 25, 15, 40, 30}}),
 		chartParams{width: 300, height: 80, strokeWidth: 2, legend: true},
 	)
-	if !strings.HasPrefix(svg, "<svg ") {
-		t.Error("expected SVG to start with <svg")
-	}
-	if !strings.HasSuffix(svg, "</svg>") {
-		t.Error("expected SVG to end with </svg>")
-	}
+	assert.True(t, strings.HasPrefix(svg, "<svg "), "expected SVG to start with <svg")
+	assert.True(t, strings.HasSuffix(svg, "</svg>"), "expected SVG to end with </svg>")
 }
 
 func TestRenderSparkline_PolylineCount(t *testing.T) {
@@ -71,10 +68,7 @@ func TestRenderSparkline_PolylineCount(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			svg := renderSparkline(tc.matrix, chartParams{width: 300, height: 80, strokeWidth: 2})
-			got := strings.Count(svg, "<polyline ")
-			if got != tc.wantLines {
-				t.Errorf("expected %d <polyline> elements, got %d", tc.wantLines, got)
-			}
+			assert.Equal(t, tc.wantLines, strings.Count(svg, "<polyline "))
 		})
 	}
 }
@@ -86,14 +80,11 @@ func TestRenderSparkline_LegendText(t *testing.T) {
 	})
 
 	withLegend := renderSparkline(matrix, chartParams{width: 300, height: 80, strokeWidth: 2, legend: true})
-	if !strings.Contains(withLegend, "server1") || !strings.Contains(withLegend, "server2") {
-		t.Error("expected legend labels in SVG when legend=true")
-	}
+	assert.Contains(t, withLegend, "server1")
+	assert.Contains(t, withLegend, "server2")
 
 	withoutLegend := renderSparkline(matrix, chartParams{width: 300, height: 80, strokeWidth: 2, legend: false})
-	if strings.Contains(withoutLegend, "<text ") {
-		t.Error("expected no <text> elements when legend=false")
-	}
+	assert.NotContains(t, withoutLegend, "<text ", "expected no <text> elements when legend=false")
 }
 
 func TestRenderSparkline_SkipsNaNAndInf(t *testing.T) {
@@ -105,12 +96,9 @@ func TestRenderSparkline_SkipsNaNAndInf(t *testing.T) {
 
 	svg := renderSparkline(matrix, chartParams{width: 300, height: 80, strokeWidth: 2})
 
-	if strings.Contains(svg, "NaN") || strings.Contains(svg, "Inf") {
-		t.Errorf("SVG contains non-finite coordinates: %s", svg)
-	}
-	if strings.Count(svg, "<polyline ") != 1 {
-		t.Error("expected the series to still render a polyline from its finite points")
-	}
+	assert.NotContains(t, svg, "NaN")
+	assert.NotContains(t, svg, "Inf")
+	assert.Equal(t, 1, strings.Count(svg, "<polyline "), "expected a polyline from the finite points")
 }
 
 func TestRenderSparkline_AllNaNSeriesSkipped(t *testing.T) {
@@ -122,9 +110,7 @@ func TestRenderSparkline_AllNaNSeriesSkipped(t *testing.T) {
 	svg := renderSparkline(matrix, chartParams{width: 300, height: 80, strokeWidth: 2})
 
 	// The all-NaN series is dropped; the finite series still draws.
-	if got := strings.Count(svg, "<polyline "); got != 1 {
-		t.Errorf("expected 1 polyline (all-NaN series skipped), got %d", got)
-	}
+	assert.Equal(t, 1, strings.Count(svg, "<polyline "), "all-NaN series should be skipped")
 }
 
 func TestRenderSparkline_FlatLineNoNaN(t *testing.T) {
@@ -132,10 +118,6 @@ func TestRenderSparkline_FlatLineNoNaN(t *testing.T) {
 		makeMatrix([][]float64{{42, 42, 42, 42, 42}}),
 		chartParams{width: 300, height: 80, strokeWidth: 2},
 	)
-	if strings.Contains(svg, "NaN") {
-		t.Error("SVG contains NaN coordinates")
-	}
-	if strings.Contains(svg, "Inf") {
-		t.Error("SVG contains Inf coordinates")
-	}
+	assert.NotContains(t, svg, "NaN")
+	assert.NotContains(t, svg, "Inf")
 }

--- a/internal/kromgo/handler.go
+++ b/internal/kromgo/handler.go
@@ -3,16 +3,12 @@
 package kromgo
 
 import (
-	"context"
-	"encoding/json"
 	"fmt"
 	"log/slog"
 	"net/http"
-	"time"
 
 	"github.com/home-operations/kromgo/internal/config"
 	"github.com/home-operations/kromgo/internal/prometheus"
-	v1 "github.com/prometheus/client_golang/api/prometheus/v1"
 	"github.com/prometheus/common/model"
 )
 
@@ -111,106 +107,6 @@ func (h *Handler) serveMetric(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-// handleInstant serves the json, raw, and badge formats. The value comes from an
-// instant query, or a reduced range query when the metric's type is "range".
-func (h *Handler) handleInstant(w http.ResponseWriter, r *http.Request, metric *resolvedMetric, format string, log *slog.Logger) {
-	value, err := h.queryValue(r.Context(), metric)
-	if err != nil {
-		log.Error("error executing metric query", "error", err)
-		writeError(w, metric.Name, "Query Error", http.StatusInternalServerError)
-		return
-	}
-
-	if format == "raw" {
-		if err := writeJSON(w, value); err != nil {
-			log.Error("could not convert query result to json", "error", err)
-			writeError(w, metric.Name, "Query Error", http.StatusInternalServerError)
-		}
-		return
-	}
-
-	vector, ok := value.(model.Vector)
-	if !ok {
-		log.Error("query did not return an instant vector", "type", value.Type().String())
-		writeError(w, metric.Name, "Unexpected result type", http.StatusInternalServerError)
-		return
-	}
-
-	if len(vector) == 0 {
-		// No data: report it without evaluating the expressions (no result/labels).
-		if err := writeJSON(w, EndpointResponse{SchemaVersion: 1, Label: metricTitle(metric), Message: "metric returned no data"}); err != nil {
-			log.Error("error writing no-data response", "error", err)
-			writeError(w, metric.Name, "Error", http.StatusInternalServerError)
-		}
-		return
-	}
-
-	message, color, ok := h.evalDisplay(metric, vector[0], log)
-	if !ok {
-		writeError(w, metric.Name, "Expression Error", http.StatusInternalServerError)
-		return
-	}
-	title := metricTitle(metric)
-
-	if format == "badge" {
-		h.badges.write(w, r.URL.Query().Get("style"), title, message, color)
-		return
-	}
-
-	resp := EndpointResponse{
-		SchemaVersion: 1,
-		Label:         title,
-		Message:       message,
-		Color:         color,               // omitted when empty
-		CacheSeconds:  metric.cacheSeconds, // shields.io honors this; omitted when 0
-	}
-	if err := writeJSON(w, resp); err != nil {
-		log.Error("error converting data to json response", "error", err)
-		writeError(w, metric.Name, "Error", http.StatusInternalServerError)
-	}
-}
-
-// evalDisplay evaluates the metric's value and color CEL expressions against a
-// sample. ok is false only if the value expression errors (caller returns 500);
-// a failing color expression is logged and treated as no color.
-func (h *Handler) evalDisplay(metric *resolvedMetric, sample *model.Sample, log *slog.Logger) (message, color string, ok bool) {
-	result := float64(sample.Value)
-	labels := labelMap(sample.Metric)
-
-	message, err := evalStringExpr(metric.valueProg, result, labels)
-	if err != nil {
-		log.Error("value expression failed", "error", err)
-		return "", "", false
-	}
-	if metric.colorProg != nil {
-		if color, err = evalStringExpr(metric.colorProg, result, labels); err != nil {
-			log.Error("color expression failed", "error", err) // degrade to no color
-			color = ""
-		}
-	}
-	return message, color, true
-}
-
-// queryValue computes the metric's instant value: an instant query for the default
-// type, or a range query reduced to one value per series for type: range.
-func (h *Handler) queryValue(ctx context.Context, metric *resolvedMetric) (model.Value, error) {
-	rq := metric.rangeQuery
-	if rq == nil {
-		return h.prom.Query(ctx, metric.Query, time.Now())
-	}
-
-	end := time.Now().Add(-rq.offset)
-	value, err := h.prom.QueryRange(ctx, metric.Query, v1.Range{Start: end.Add(-rq.last), End: end, Step: rq.step})
-	if err != nil {
-		return nil, err
-	}
-	matrix, ok := value.(model.Matrix)
-	if !ok {
-		return nil, fmt.Errorf("range query returned %s, want matrix", value.Type())
-	}
-	return reduceMatrix(matrix, rq.reduce), nil
-}
-
 // labelMap converts a Prometheus label set to a plain string map for CEL/JSON use.
 func labelMap(m model.Metric) map[string]string {
 	out := make(map[string]string, len(m))
@@ -218,29 +114,6 @@ func labelMap(m model.Metric) map[string]string {
 		out[string(k)] = string(v)
 	}
 	return out
-}
-
-// metricTitle returns the display title for a metric (its Title, falling back to Name).
-func metricTitle(metric *resolvedMetric) string {
-	if metric.Title != "" {
-		return metric.Title
-	}
-	return metric.Name
-}
-
-func writeJSON(w http.ResponseWriter, v any) error {
-	body, err := json.Marshal(v)
-	if err != nil {
-		return err
-	}
-	w.Header().Set("Content-Type", "application/json")
-	_, _ = w.Write(body)
-	return nil
-}
-
-func writeSVG(w http.ResponseWriter, svg []byte) {
-	w.Header().Set("Content-Type", "image/svg+xml")
-	_, _ = w.Write(svg)
 }
 
 func requestLogger(r *http.Request, metric, format string) *slog.Logger {

--- a/internal/kromgo/handler_test.go
+++ b/internal/kromgo/handler_test.go
@@ -46,14 +46,6 @@ func baseConfig() config.KromgoConfig {
 	}
 }
 
-func doGet(t *testing.T, h *Handler, target string) *httptest.ResponseRecorder {
-	t.Helper()
-	req := httptest.NewRequest(http.MethodGet, target, nil)
-	w := httptest.NewRecorder()
-	h.Mux().ServeHTTP(w, req)
-	return w
-}
-
 func counterValue(t *testing.T, c promclient.Counter) float64 {
 	t.Helper()
 	var m dto.Metric
@@ -68,8 +60,8 @@ func TestServeMetric_CounterCardinalityBounded(t *testing.T) {
 	h := newHandlerForTest(t, baseConfig(), srv.URL)
 
 	before := counterValue(t, requestsTotal.WithLabelValues("unknown", "json"))
-	doGet(t, h, "/does-not-exist")
-	doGet(t, h, "/also-missing?format=bogus")
+	promtest.Get(t, h.Mux(), "/does-not-exist")
+	promtest.Get(t, h.Mux(), "/also-missing?format=bogus")
 	after := counterValue(t, requestsTotal.WithLabelValues("unknown", "json"))
 
 	assert.Equal(t, before+2, after)
@@ -79,7 +71,7 @@ func TestServeMetric_JSON(t *testing.T) {
 	srv := mockProm(t, "17.5", nil)
 	h := newHandlerForTest(t, baseConfig(), srv.URL)
 
-	w := doGet(t, h, "/cpu")
+	w := promtest.Get(t, h.Mux(), "/cpu")
 
 	assert.Equal(t, http.StatusOK, w.Code)
 	assert.Equal(t, "application/json", w.Header().Get("Content-Type"))
@@ -95,7 +87,7 @@ func TestServeMetric_QueryParamForm(t *testing.T) {
 	srv := mockProm(t, "17.5", nil)
 	h := newHandlerForTest(t, baseConfig(), srv.URL)
 
-	w := doGet(t, h, "/query?metric=cpu")
+	w := promtest.Get(t, h.Mux(), "/query?metric=cpu")
 
 	assert.Equal(t, http.StatusOK, w.Code)
 	assert.Contains(t, w.Body.String(), `"label":"cpu"`)
@@ -105,7 +97,7 @@ func TestServeMetric_Raw(t *testing.T) {
 	srv := mockProm(t, "17.5", nil)
 	h := newHandlerForTest(t, baseConfig(), srv.URL)
 
-	w := doGet(t, h, "/cpu?format=raw")
+	w := promtest.Get(t, h.Mux(), "/cpu?format=raw")
 
 	assert.Equal(t, http.StatusOK, w.Code)
 	assert.Equal(t, "application/json", w.Header().Get("Content-Type"))
@@ -118,7 +110,7 @@ func TestServeMetric_Badge(t *testing.T) {
 	h := newHandlerForTest(t, baseConfig(), srv.URL)
 
 	for _, style := range []string{"", "flat-square", "plastic"} {
-		w := doGet(t, h, "/cpu?format=badge&style="+style)
+		w := promtest.Get(t, h.Mux(), "/cpu?format=badge&style="+style)
 		assert.Equal(t, http.StatusOK, w.Code, "style=%q", style)
 		assert.Equal(t, "image/svg+xml", w.Header().Get("Content-Type"), "style=%q", style)
 		assert.True(t, strings.HasPrefix(w.Body.String(), "<svg"), "style=%q", style)
@@ -142,7 +134,7 @@ func TestServeMetric_NotFound(t *testing.T) {
 	srv := mockProm(t, "17.5", nil)
 	h := newHandlerForTest(t, baseConfig(), srv.URL)
 
-	w := doGet(t, h, "/does-not-exist")
+	w := promtest.Get(t, h.Mux(), "/does-not-exist")
 
 	assert.Equal(t, http.StatusNotFound, w.Code)
 	assert.Contains(t, w.Body.String(), `"isError":true`)
@@ -159,7 +151,7 @@ func TestServeMetric_ValueExpression(t *testing.T) {
 	srv := mockProm(t, "9000", nil)
 	h := newHandlerForTest(t, cfg, srv.URL)
 
-	w := doGet(t, h, "/uptime")
+	w := promtest.Get(t, h.Mux(), "/uptime")
 
 	assert.Equal(t, http.StatusOK, w.Code)
 	assert.Contains(t, w.Body.String(), `"message":"2h30m"`)
@@ -169,7 +161,7 @@ func TestServeMetric_History(t *testing.T) {
 	srv := mockProm(t, "0", []float64{1, 2, 3})
 	h := newHandlerForTest(t, baseConfig(), srv.URL)
 
-	w := doGet(t, h, "/cpu?format=history&last=1h")
+	w := promtest.Get(t, h.Mux(), "/cpu?format=history&last=1h")
 
 	assert.Equal(t, http.StatusOK, w.Code)
 	assert.Equal(t, "application/json", w.Header().Get("Content-Type"))
@@ -186,7 +178,7 @@ func TestServeMetric_HistoryDisabled(t *testing.T) {
 	srv := mockProm(t, "0", []float64{1, 2, 3})
 	h := newHandlerForTest(t, cfg, srv.URL)
 
-	w := doGet(t, h, "/cpu?format=history")
+	w := promtest.Get(t, h.Mux(), "/cpu?format=history")
 
 	assert.Equal(t, http.StatusForbidden, w.Code)
 }
@@ -195,7 +187,7 @@ func TestServeMetric_Chart(t *testing.T) {
 	srv := mockProm(t, "0", []float64{10, 20, 15, 30})
 	h := newHandlerForTest(t, baseConfig(), srv.URL)
 
-	w := doGet(t, h, "/cpu?format=chart&last=1h")
+	w := promtest.Get(t, h.Mux(), "/cpu?format=chart&last=1h")
 
 	assert.Equal(t, http.StatusOK, w.Code)
 	assert.Equal(t, "image/svg+xml", w.Header().Get("Content-Type"))
@@ -206,7 +198,7 @@ func TestServeMetric_HistoryWindowTooLarge(t *testing.T) {
 	srv := mockProm(t, "0", []float64{1, 2})
 	h := newHandlerForTest(t, baseConfig(), srv.URL) // MaxDuration 24h
 
-	w := doGet(t, h, "/cpu?format=history&last=7d")
+	w := promtest.Get(t, h.Mux(), "/cpu?format=history&last=7d")
 
 	assert.Equal(t, http.StatusBadRequest, w.Code)
 }
@@ -216,7 +208,7 @@ func TestServeMetric_ValueFromLabel(t *testing.T) {
 	cfg := config.KromgoConfig{Metrics: []config.Metric{{Name: "ver", Query: "q", Value: `labels["version"]`}}}
 	h := newHandlerForTest(t, cfg, srv.URL)
 
-	w := doGet(t, h, "/ver")
+	w := promtest.Get(t, h.Mux(), "/ver")
 
 	assert.Equal(t, http.StatusOK, w.Code)
 	assert.Contains(t, w.Body.String(), `"message":"v1.2.3"`)
@@ -228,7 +220,7 @@ func TestServeMetric_ValueExpressionError(t *testing.T) {
 	cfg := config.KromgoConfig{Metrics: []config.Metric{{Name: "ver", Query: "q", Value: `labels["version"]`}}}
 	h := newHandlerForTest(t, cfg, srv.URL)
 
-	w := doGet(t, h, "/ver")
+	w := promtest.Get(t, h.Mux(), "/ver")
 
 	assert.Equal(t, http.StatusInternalServerError, w.Code)
 	assert.Contains(t, w.Body.String(), `"isError":true`)
@@ -244,7 +236,7 @@ func TestServeMetric_StateExpressions(t *testing.T) {
 	srv := mockProm(t, "0", nil)
 	h := newHandlerForTest(t, cfg, srv.URL)
 
-	w := doGet(t, h, "/ceph")
+	w := promtest.Get(t, h.Mux(), "/ceph")
 
 	assert.Equal(t, http.StatusOK, w.Code)
 	assert.Contains(t, w.Body.String(), `"message":"Healthy"`)
@@ -255,7 +247,7 @@ func TestServeMetric_EmptyVector_NoData(t *testing.T) {
 	srv := promtest.Server(t, nil, nil) // empty instant vector
 	h := newHandlerForTest(t, baseConfig(), srv.URL)
 
-	w := doGet(t, h, "/cpu")
+	w := promtest.Get(t, h.Mux(), "/cpu")
 
 	assert.Equal(t, http.StatusOK, w.Code)
 	assert.Contains(t, w.Body.String(), "metric returned no data")
@@ -273,13 +265,13 @@ func TestCacheControl_PerMetric(t *testing.T) {
 	h := newHandlerForTest(t, cfg, srv.URL)
 
 	t.Run("global default", func(t *testing.T) {
-		w := doGet(t, h, "/fast")
+		w := promtest.Get(t, h.Mux(), "/fast")
 		assert.Equal(t, "public, max-age=60", w.Header().Get("Cache-Control"))
 		assert.Contains(t, w.Body.String(), `"cacheSeconds":60`)
 	})
 
 	t.Run("per-metric override", func(t *testing.T) {
-		w := doGet(t, h, "/slow")
+		w := promtest.Get(t, h.Mux(), "/slow")
 		assert.Equal(t, "public, max-age=3600", w.Header().Get("Cache-Control"))
 		assert.Contains(t, w.Body.String(), `"cacheSeconds":3600`)
 	})
@@ -289,7 +281,7 @@ func TestCacheControl_DisabledByDefault(t *testing.T) {
 	srv := mockProm(t, "17.5", nil)
 	h := newHandlerForTest(t, baseConfig(), srv.URL) // no CacheSeconds
 
-	w := doGet(t, h, "/cpu")
+	w := promtest.Get(t, h.Mux(), "/cpu")
 
 	assert.Empty(t, w.Header().Get("Cache-Control"))
 	assert.NotContains(t, w.Body.String(), "cacheSeconds")
@@ -304,7 +296,7 @@ func TestCacheControl_ErrorsNotCached(t *testing.T) {
 	h := newHandlerForTest(t, cfg, srv.URL)
 
 	// Range queries are disabled → 403 error; the cache header must be no-store, not max-age.
-	w := doGet(t, h, "/cpu?format=history")
+	w := promtest.Get(t, h.Mux(), "/cpu?format=history")
 
 	assert.Equal(t, http.StatusForbidden, w.Code)
 	assert.Equal(t, "no-store", w.Header().Get("Cache-Control"))
@@ -324,7 +316,7 @@ func TestServeMetric_RangeType(t *testing.T) {
 	srv := promtest.Server(t, nil, []float64{10, 20, 30})
 	h := newHandlerForTest(t, cfg, srv.URL)
 
-	w := doGet(t, h, "/cpu_avg")
+	w := promtest.Get(t, h.Mux(), "/cpu_avg")
 
 	assert.Equal(t, http.StatusOK, w.Code)
 	assert.Contains(t, w.Body.String(), `"message":"20%"`)
@@ -336,7 +328,7 @@ func TestIndexRoute(t *testing.T) {
 	srv := mockProm(t, "0", nil)
 	h := newHandlerForTest(t, cfg, srv.URL)
 
-	w := doGet(t, h, "/")
+	w := promtest.Get(t, h.Mux(), "/")
 
 	assert.Equal(t, http.StatusOK, w.Code)
 	assert.Contains(t, w.Body.String(), `<a href="/cpu">cpu</a>`)

--- a/internal/kromgo/history.go
+++ b/internal/kromgo/history.go
@@ -3,12 +3,6 @@ package kromgo
 import (
 	"log/slog"
 	"net/http"
-	"strconv"
-	"time"
-
-	"github.com/home-operations/kromgo/internal/config"
-	v1 "github.com/prometheus/client_golang/api/prometheus/v1"
-	"github.com/prometheus/common/model"
 )
 
 type HistoryDataPoint struct {
@@ -28,90 +22,6 @@ type HistoryResponse struct {
 	End    int64           `json:"end"`
 	Step   int64           `json:"step"`
 	Series []HistorySeries `json:"series"`
-}
-
-var (
-	errStartAfterEnd       = &historyParamError{"start must be before end"}
-	errNonPositiveDuration = &historyParamError{"last must be a positive duration"}
-)
-
-type historyParamError struct{ msg string }
-
-func (e *historyParamError) Error() string { return e.msg }
-
-func parseTimeParam(s string) (time.Time, error) {
-	// Try Unix timestamp (integer) first, then fall back to RFC3339.
-	if ts, err := strconv.ParseInt(s, 10, 64); err == nil {
-		return time.Unix(ts, 0), nil
-	}
-	return time.Parse(time.RFC3339, s)
-}
-
-func parseHistoryParams(r *http.Request) (start, end time.Time, step time.Duration, err error) {
-	now := time.Now()
-	q := r.URL.Query()
-
-	// last=7d is shorthand for start=now-7d&end=now.
-	if s := q.Get("last"); s != "" {
-		d, derr := config.ParseDuration(s)
-		if derr != nil {
-			return start, end, step, derr
-		}
-		if d <= 0 {
-			return start, end, step, errNonPositiveDuration
-		}
-		end, start = now, now.Add(-d)
-	} else {
-		end = now
-		if s := q.Get("end"); s != "" {
-			if end, err = parseTimeParam(s); err != nil {
-				return start, end, step, err
-			}
-		}
-
-		start = end.Add(-1 * time.Hour)
-		if s := q.Get("start"); s != "" {
-			if start, err = parseTimeParam(s); err != nil {
-				return start, end, step, err
-			}
-		}
-
-		if start.After(end) {
-			return start, end, step, errStartAfterEnd
-		}
-	}
-
-	step = autoStep(end.Sub(start))
-	if s := q.Get("step"); s != "" {
-		if step, err = config.ParseDuration(s); err != nil {
-			return start, end, step, err
-		}
-		step = max(step, minRangeStep)
-	}
-
-	return start, end, step, nil
-}
-
-// validateHistoryAccess checks access control, parses time parameters, and enforces the
-// max duration cap. Returns ok=false if an error response was already written.
-func (h *Handler) validateHistoryAccess(w http.ResponseWriter, r *http.Request, metric *resolvedMetric) (start, end time.Time, step time.Duration, ok bool) {
-	if !metric.historyEnabled {
-		writeError(w, metric.Name, "History not enabled for this metric", http.StatusForbidden)
-		return start, end, step, false
-	}
-
-	start, end, step, err := parseHistoryParams(r)
-	if err != nil {
-		writeError(w, metric.Name, "Invalid parameter: "+err.Error(), http.StatusBadRequest)
-		return start, end, step, false
-	}
-
-	if metric.historyMax > 0 && end.Sub(start) > metric.historyMax {
-		writeError(w, metric.Name, "Requested time window exceeds maximum allowed duration", http.StatusBadRequest)
-		return start, end, step, false
-	}
-
-	return start, end, step, true
 }
 
 func (h *Handler) handleHistory(w http.ResponseWriter, r *http.Request, metric *resolvedMetric, log *slog.Logger) {
@@ -151,22 +61,4 @@ func (h *Handler) handleHistory(w http.ResponseWriter, r *http.Request, metric *
 		log.Error("error marshaling history response", "error", err)
 		writeError(w, metric.Name, "Error", http.StatusInternalServerError)
 	}
-}
-
-// queryMatrix runs a range query and asserts the result is a matrix, writing an error
-// response and returning ok=false otherwise.
-func (h *Handler) queryMatrix(w http.ResponseWriter, r *http.Request, metric *resolvedMetric, start, end time.Time, step time.Duration, log *slog.Logger) (model.Matrix, bool) {
-	value, err := h.prom.QueryRange(r.Context(), metric.Query, v1.Range{Start: start, End: end, Step: step})
-	if err != nil {
-		log.Error("error executing range query", "error", err)
-		writeError(w, metric.Name, "Query Error", http.StatusInternalServerError)
-		return nil, false
-	}
-	matrix, ok := value.(model.Matrix)
-	if !ok {
-		log.Error("range query did not return a matrix", "type", value.Type().String())
-		writeError(w, metric.Name, "Unexpected result type", http.StatusInternalServerError)
-		return nil, false
-	}
-	return matrix, true
 }

--- a/internal/kromgo/history_test.go
+++ b/internal/kromgo/history_test.go
@@ -7,6 +7,8 @@ import (
 	"time"
 
 	"github.com/home-operations/kromgo/internal/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func makeRequest(params map[string]string) *http.Request {
@@ -17,249 +19,113 @@ func makeRequest(params map[string]string) *http.Request {
 	return &http.Request{URL: &url.URL{RawQuery: q.Encode()}}
 }
 
-func TestParseHistoryParams_Defaults(t *testing.T) {
+func TestParseHistoryParams_Valid(t *testing.T) {
+	// Cases with absolute start/end. wantStart/wantEnd of 0 and wantStep of 0 mean
+	// "don't assert this field".
+	cases := []struct {
+		name      string
+		params    map[string]string
+		wantStart int64
+		wantEnd   int64
+		wantStep  time.Duration
+	}{
+		{"rfc3339", map[string]string{"start": "2024-01-01T00:00:00Z", "end": "2024-01-01T06:00:00Z"}, 1704067200, 1704088800, 0},
+		{"unix timestamp", map[string]string{"start": "1704067200", "end": "1704088800"}, 1704067200, 1704088800, 0},
+		{"explicit step", map[string]string{"start": "1704067200", "end": "1704088800", "step": "5m"}, 0, 0, 5 * time.Minute},
+		{"step clamped to minute", map[string]string{"start": "1704067200", "end": "1704088800", "step": "10s"}, 0, 0, time.Minute},
+		{"auto step on larger window", map[string]string{"start": "1704067200", "end": "1704427200"}, 0, 0, time.Hour}, // 100h/100
+		{"step in days", map[string]string{"start": "1704067200", "end": "1704672000", "step": "1d"}, 0, 0, 24 * time.Hour},
+		{"last overrides start/end", map[string]string{"last": "1d", "start": "1704067200", "end": "1704088800"}, 0, 0, 0},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			start, end, step, err := parseHistoryParams(makeRequest(tc.params))
+			require.NoError(t, err)
+			if tc.wantStart != 0 {
+				assert.Equal(t, tc.wantStart, start.Unix())
+			}
+			if tc.wantEnd != 0 {
+				assert.Equal(t, tc.wantEnd, end.Unix())
+			}
+			if tc.wantStep != 0 {
+				assert.Equal(t, tc.wantStep, step)
+			}
+		})
+	}
+}
+
+func TestParseHistoryParams_DefaultWindow(t *testing.T) {
 	before := time.Now()
-	r := makeRequest(nil)
-	start, end, step, err := parseHistoryParams(r)
-	after := time.Now()
-
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if end.Before(before) || end.After(after) {
-		t.Errorf("end not near now: %v", end)
-	}
-	if end.Sub(start) < 59*time.Minute || end.Sub(start) > 61*time.Minute {
-		t.Errorf("default start not ~1h before end: diff=%v", end.Sub(start))
-	}
-	if step != time.Minute {
-		t.Errorf("expected step=1m (clamped), got %v", step)
-	}
-}
-
-func TestParseHistoryParams_RFC3339(t *testing.T) {
-	r := makeRequest(map[string]string{
-		"start": "2024-01-01T00:00:00Z",
-		"end":   "2024-01-01T06:00:00Z",
-	})
-	start, end, _, err := parseHistoryParams(r)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if start.Unix() != 1704067200 {
-		t.Errorf("wrong start: %v", start)
-	}
-	if end.Unix() != 1704088800 {
-		t.Errorf("wrong end: %v", end)
-	}
-}
-
-func TestParseHistoryParams_UnixTimestamp(t *testing.T) {
-	r := makeRequest(map[string]string{
-		"start": "1704067200",
-		"end":   "1704088800",
-	})
-	start, end, _, err := parseHistoryParams(r)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if start.Unix() != 1704067200 {
-		t.Errorf("wrong start: %v", start)
-	}
-	if end.Unix() != 1704088800 {
-		t.Errorf("wrong end: %v", end)
-	}
-}
-
-func TestParseHistoryParams_ExplicitStep(t *testing.T) {
-	r := makeRequest(map[string]string{
-		"start": "1704067200",
-		"end":   "1704088800",
-		"step":  "5m",
-	})
-	_, _, step, err := parseHistoryParams(r)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if step != 5*time.Minute {
-		t.Errorf("expected 5m, got %v", step)
-	}
-}
-
-func TestParseHistoryParams_StepClampedToMinute(t *testing.T) {
-	r := makeRequest(map[string]string{
-		"start": "1704067200",
-		"end":   "1704088800",
-		"step":  "10s",
-	})
-	_, _, step, err := parseHistoryParams(r)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if step != time.Minute {
-		t.Errorf("expected step clamped to 1m, got %v", step)
-	}
-}
-
-func TestParseHistoryParams_AutoStepLargerWindow(t *testing.T) {
-	// 100h window: auto step = 100h/100 = 1h
-	r := makeRequest(map[string]string{
-		"start": "1704067200",
-		"end":   "1704427200", // +100h
-	})
-	_, _, step, err := parseHistoryParams(r)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if step != time.Hour {
-		t.Errorf("expected auto step=1h, got %v", step)
-	}
+	start, end, step, err := parseHistoryParams(makeRequest(nil))
+	require.NoError(t, err)
+	assert.WithinDuration(t, before, end, time.Second, "end defaults to ~now")
+	assert.WithinDuration(t, before.Add(-time.Hour), start, time.Second, "start defaults to ~1h before end")
+	assert.Equal(t, time.Minute, step, "autoStep(1h) clamps to 1m")
 }
 
 func TestParseHistoryParams_Last(t *testing.T) {
 	before := time.Now()
-	r := makeRequest(map[string]string{"last": "7d"})
-	start, end, _, err := parseHistoryParams(r)
-	after := time.Now()
+	start, end, _, err := parseHistoryParams(makeRequest(map[string]string{"last": "7d"}))
+	require.NoError(t, err)
+	assert.WithinDuration(t, before, end, time.Second)
+	assert.WithinDuration(t, before.Add(-7*24*time.Hour), start, time.Second)
+}
 
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
+func TestParseHistoryParams_Errors(t *testing.T) {
+	cases := []struct {
+		name     string
+		params   map[string]string
+		sentinel error // nil means any error is acceptable
+	}{
+		{"invalid last", map[string]string{"last": "invalid"}, nil},
+		{"negative last", map[string]string{"last": "-1h"}, errNonPositiveDuration},
+		{"zero last", map[string]string{"last": "0"}, errNonPositiveDuration},
+		{"start after end", map[string]string{"start": "1704088800", "end": "1704067200"}, errStartAfterEnd},
+		{"invalid start", map[string]string{"start": "not-a-time"}, nil},
+		{"invalid end", map[string]string{"end": "not-a-time"}, nil},
+		{"invalid step", map[string]string{"start": "1704067200", "end": "1704088800", "step": "invalid"}, nil},
 	}
-	if end.Before(before) || end.After(after) {
-		t.Errorf("end not near now: %v", end)
-	}
-	if diff := end.Sub(start); diff < 7*24*time.Hour-time.Second || diff > 7*24*time.Hour+time.Second {
-		t.Errorf("expected ~7d window, got %v", diff)
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, _, _, err := parseHistoryParams(makeRequest(tc.params))
+			require.Error(t, err)
+			if tc.sentinel != nil {
+				assert.ErrorIs(t, err, tc.sentinel)
+			}
+		})
 	}
 }
 
-func TestParseHistoryParams_LastOverridesStartEnd(t *testing.T) {
-	r := makeRequest(map[string]string{
-		"last":  "1d",
-		"start": "1704067200",
-		"end":   "1704088800",
-	})
-	if _, _, _, err := parseHistoryParams(r); err != nil {
-		t.Fatalf("unexpected error: %v", err)
+func TestParseTimeParam(t *testing.T) {
+	cases := []struct {
+		name     string
+		in       string
+		wantUnix int64
+		wantErr  bool
+	}{
+		{"rfc3339", "2024-01-01T00:00:00Z", 1704067200, false},
+		{"unix", "1704067200", 1704067200, false},
+		{"invalid", "garbage", 0, true},
 	}
-	// last takes precedence — no start-after-end error despite conflicting params
-}
-
-func TestParseHistoryParams_LastInvalid(t *testing.T) {
-	r := makeRequest(map[string]string{"last": "invalid"})
-	if _, _, _, err := parseHistoryParams(r); err == nil {
-		t.Fatal("expected error for invalid last param")
-	}
-}
-
-func TestParseHistoryParams_LastNegative(t *testing.T) {
-	r := makeRequest(map[string]string{"last": "-1h"})
-	_, _, _, err := parseHistoryParams(r)
-	if err == nil {
-		t.Fatal("expected error for negative last param")
-	}
-	if err != errNonPositiveDuration {
-		t.Errorf("expected errNonPositiveDuration, got %v", err)
-	}
-}
-
-func TestParseHistoryParams_LastZero(t *testing.T) {
-	r := makeRequest(map[string]string{"last": "0"})
-	_, _, _, err := parseHistoryParams(r)
-	if err == nil {
-		t.Fatal("expected error for zero last param")
-	}
-	if err != errNonPositiveDuration {
-		t.Errorf("expected errNonPositiveDuration, got %v", err)
-	}
-}
-
-func TestParseHistoryParams_StartAfterEnd(t *testing.T) {
-	r := makeRequest(map[string]string{
-		"start": "1704088800",
-		"end":   "1704067200",
-	})
-	if _, _, _, err := parseHistoryParams(r); err == nil {
-		t.Fatal("expected error for start > end")
-	}
-}
-
-func TestParseHistoryParams_InvalidStart(t *testing.T) {
-	r := makeRequest(map[string]string{"start": "not-a-time"})
-	if _, _, _, err := parseHistoryParams(r); err == nil {
-		t.Fatal("expected error for invalid start")
-	}
-}
-
-func TestParseHistoryParams_InvalidEnd(t *testing.T) {
-	r := makeRequest(map[string]string{"end": "not-a-time"})
-	if _, _, _, err := parseHistoryParams(r); err == nil {
-		t.Fatal("expected error for invalid end")
-	}
-}
-
-func TestParseHistoryParams_InvalidStep(t *testing.T) {
-	r := makeRequest(map[string]string{
-		"start": "1704067200",
-		"end":   "1704088800",
-		"step":  "invalid",
-	})
-	if _, _, _, err := parseHistoryParams(r); err == nil {
-		t.Fatal("expected error for invalid step")
-	}
-}
-
-func TestParseHistoryParams_StepDays(t *testing.T) {
-	r := makeRequest(map[string]string{
-		"start": "1704067200",
-		"end":   "1704672000", // +7d
-		"step":  "1d",
-	})
-	_, _, step, err := parseHistoryParams(r)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if step != 24*time.Hour {
-		t.Errorf("expected 24h step, got %v", step)
-	}
-}
-
-func TestParseTimeParam_RFC3339(t *testing.T) {
-	ts, err := parseTimeParam("2024-01-01T00:00:00Z")
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if ts.Unix() != 1704067200 {
-		t.Errorf("wrong timestamp: %v", ts.Unix())
-	}
-}
-
-func TestParseTimeParam_Unix(t *testing.T) {
-	ts, err := parseTimeParam("1704067200")
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if ts.Unix() != 1704067200 {
-		t.Errorf("wrong timestamp: %v", ts.Unix())
-	}
-}
-
-func TestParseTimeParam_Invalid(t *testing.T) {
-	if _, err := parseTimeParam("garbage"); err == nil {
-		t.Fatal("expected error for invalid time param")
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ts, err := parseTimeParam(tc.in)
+			if tc.wantErr {
+				assert.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tc.wantUnix, ts.Unix())
+		})
 	}
 }
 
 func mustResolve(t *testing.T, m config.Metric, cfg config.KromgoConfig) *resolvedMetric {
 	t.Helper()
 	env, err := newCELEnv()
-	if err != nil {
-		t.Fatalf("newCELEnv: %v", err)
-	}
+	require.NoError(t, err)
 	rm, err := resolveMetric(m, cfg, env)
-	if err != nil {
-		t.Fatalf("resolveMetric: %v", err)
-	}
+	require.NoError(t, err)
 	return rm
 }
 
@@ -268,78 +134,58 @@ func tsDefaults(rc config.TimeseriesConfig) config.KromgoConfig {
 	return config.KromgoConfig{Defaults: config.Defaults{Timeseries: rc}}
 }
 
-func TestResolveMetric_TimeseriesEnabled_DefaultOff(t *testing.T) {
-	rm := mustResolve(t, config.Metric{Name: "test"}, tsDefaults(config.TimeseriesConfig{Enabled: false}))
-	if rm.historyEnabled {
-		t.Error("expected range disabled by default")
+func TestResolveMetric_HistoryEnabled(t *testing.T) {
+	cases := []struct {
+		name     string
+		metric   config.Metric
+		defaults config.TimeseriesConfig
+		want     bool
+	}{
+		{"default off", config.Metric{Name: "test"}, config.TimeseriesConfig{Enabled: false}, false},
+		{"default on", config.Metric{Name: "test"}, config.TimeseriesConfig{Enabled: true}, true},
+		{"per-metric override on", config.Metric{Name: "test", Timeseries: &config.MetricTimeseriesConfig{Enabled: new(true)}}, config.TimeseriesConfig{Enabled: false}, true},
+		{"per-metric override off", config.Metric{Name: "test", Timeseries: &config.MetricTimeseriesConfig{Enabled: new(false)}}, config.TimeseriesConfig{Enabled: true}, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			rm := mustResolve(t, tc.metric, tsDefaults(tc.defaults))
+			assert.Equal(t, tc.want, rm.historyEnabled)
+		})
 	}
 }
 
-func TestResolveMetric_TimeseriesEnabled_DefaultOn(t *testing.T) {
-	rm := mustResolve(t, config.Metric{Name: "test"}, tsDefaults(config.TimeseriesConfig{Enabled: true}))
-	if !rm.historyEnabled {
-		t.Error("expected range enabled via defaults")
+func TestResolveMetric_HistoryMax(t *testing.T) {
+	cases := []struct {
+		name   string
+		metric config.Metric
+		cfg    config.KromgoConfig
+		want   time.Duration
+	}{
+		{"built-in default", config.Metric{Name: "test"}, config.KromgoConfig{}, time.Hour},
+		{"default configured", config.Metric{Name: "test"}, tsDefaults(config.TimeseriesConfig{MaxDuration: "24h"}), 24 * time.Hour},
+		{"per-metric overrides default", config.Metric{Name: "test", Timeseries: &config.MetricTimeseriesConfig{MaxDuration: "720h"}}, tsDefaults(config.TimeseriesConfig{MaxDuration: "24h"}), 720 * time.Hour},
+		{"unlimited", config.Metric{Name: "test"}, tsDefaults(config.TimeseriesConfig{MaxDuration: "0"}), 0},
 	}
-}
-
-func TestResolveMetric_TimeseriesEnabled_PerMetricOverrideOn(t *testing.T) {
-	m := config.Metric{Name: "test", Timeseries: &config.MetricTimeseriesConfig{Enabled: new(true)}}
-	rm := mustResolve(t, m, tsDefaults(config.TimeseriesConfig{Enabled: false}))
-	if !rm.historyEnabled {
-		t.Error("expected per-metric override to enable range")
-	}
-}
-
-func TestResolveMetric_TimeseriesEnabled_PerMetricOverrideOff(t *testing.T) {
-	m := config.Metric{Name: "test", Timeseries: &config.MetricTimeseriesConfig{Enabled: new(false)}}
-	rm := mustResolve(t, m, tsDefaults(config.TimeseriesConfig{Enabled: true}))
-	if rm.historyEnabled {
-		t.Error("expected per-metric override to disable range")
-	}
-}
-
-func TestResolveMetric_TimeseriesMax_Default(t *testing.T) {
-	rm := mustResolve(t, config.Metric{Name: "test"}, config.KromgoConfig{})
-	if rm.historyMax != time.Hour {
-		t.Errorf("expected default max duration 1h, got %v", rm.historyMax)
-	}
-}
-
-func TestResolveMetric_TimeseriesMax_DefaultConfigured(t *testing.T) {
-	rm := mustResolve(t, config.Metric{Name: "test"}, tsDefaults(config.TimeseriesConfig{MaxDuration: "24h"}))
-	if rm.historyMax != 24*time.Hour {
-		t.Errorf("expected 24h, got %v", rm.historyMax)
-	}
-}
-
-func TestResolveMetric_TimeseriesMax_PerMetricOverridesDefault(t *testing.T) {
-	m := config.Metric{Name: "test", Timeseries: &config.MetricTimeseriesConfig{MaxDuration: "720h"}}
-	rm := mustResolve(t, m, tsDefaults(config.TimeseriesConfig{MaxDuration: "24h"}))
-	if rm.historyMax != 720*time.Hour {
-		t.Errorf("expected 720h, got %v", rm.historyMax)
-	}
-}
-
-func TestResolveMetric_TimeseriesMax_Unlimited(t *testing.T) {
-	rm := mustResolve(t, config.Metric{Name: "test"}, tsDefaults(config.TimeseriesConfig{MaxDuration: "0"}))
-	if rm.historyMax != 0 {
-		t.Errorf("expected 0 (unlimited), got %v", rm.historyMax)
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			rm := mustResolve(t, tc.metric, tc.cfg)
+			assert.Equal(t, tc.want, rm.historyMax)
+		})
 	}
 }
 
 func TestResolveMetric_InvalidExprFailsFast(t *testing.T) {
 	env, err := newCELEnv()
-	if err != nil {
-		t.Fatalf("newCELEnv: %v", err)
-	}
+	require.NoError(t, err)
 	cases := map[string]config.Metric{
 		"syntax error":  {Name: "a", Value: "result +"},
 		"not a string":  {Name: "b", Value: "result"},       // value must be string
 		"unknown ident": {Name: "c", Color: "nope(result)"}, // bad color expr
 	}
 	for name, m := range cases {
-		if _, err := resolveMetric(m, config.KromgoConfig{}, env); err == nil {
-			t.Errorf("%s: expected resolveMetric to reject the expression", name)
-		}
+		t.Run(name, func(t *testing.T) {
+			_, err := resolveMetric(m, config.KromgoConfig{}, env)
+			assert.Error(t, err)
+		})
 	}
 }

--- a/internal/kromgo/index_test.go
+++ b/internal/kromgo/index_test.go
@@ -3,7 +3,6 @@ package kromgo
 import (
 	"net/http"
 	"net/http/httptest"
-	"strings"
 	"testing"
 
 	"github.com/home-operations/kromgo/internal/config"
@@ -12,39 +11,26 @@ import (
 
 // --- isHidden ---
 
-func TestIsHidden_NoGlobal_NoPerMetric_DefaultsTrue(t *testing.T) {
-	m := config.Metric{Name: "foo"}
-	assert.True(t, isHidden(m, nil))
-}
-
-func TestIsHidden_GlobalFalse_NoPerMetric_Visible(t *testing.T) {
-	m := config.Metric{Name: "foo"}
-	assert.False(t, isHidden(m, new(false)))
-}
-
-func TestIsHidden_GlobalTrue_NoPerMetric_Hidden(t *testing.T) {
-	m := config.Metric{Name: "foo"}
-	assert.True(t, isHidden(m, new(true)))
-}
-
-func TestIsHidden_GlobalFalse_PerMetricTrue_Hidden(t *testing.T) {
-	m := config.Metric{Name: "foo", Hidden: new(true)}
-	assert.True(t, isHidden(m, new(false)))
-}
-
-func TestIsHidden_GlobalTrue_PerMetricFalse_Visible(t *testing.T) {
-	m := config.Metric{Name: "foo", Hidden: new(false)}
-	assert.False(t, isHidden(m, new(true)))
-}
-
-func TestIsHidden_NoGlobal_PerMetricFalse_Visible(t *testing.T) {
-	m := config.Metric{Name: "foo", Hidden: new(false)}
-	assert.False(t, isHidden(m, nil))
-}
-
-func TestIsHidden_NoGlobal_PerMetricTrue_Hidden(t *testing.T) {
-	m := config.Metric{Name: "foo", Hidden: new(true)}
-	assert.True(t, isHidden(m, nil))
+func TestIsHidden(t *testing.T) {
+	cases := []struct {
+		name          string
+		metric        config.Metric
+		defaultHidden *bool
+		want          bool
+	}{
+		{"no global, no per-metric defaults to hidden", config.Metric{Name: "foo"}, nil, true},
+		{"global false, no per-metric is visible", config.Metric{Name: "foo"}, new(false), false},
+		{"global true, no per-metric is hidden", config.Metric{Name: "foo"}, new(true), true},
+		{"per-metric true overrides global false", config.Metric{Name: "foo", Hidden: new(true)}, new(false), true},
+		{"per-metric false overrides global true", config.Metric{Name: "foo", Hidden: new(false)}, new(true), false},
+		{"per-metric false, no global", config.Metric{Name: "foo", Hidden: new(false)}, nil, false},
+		{"per-metric true, no global", config.Metric{Name: "foo", Hidden: new(true)}, nil, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, isHidden(tc.metric, tc.defaultHidden))
+		})
+	}
 }
 
 // --- index ---
@@ -133,5 +119,5 @@ func TestIndexHandler_NoMetrics_ShowsIntentionallyBlank(t *testing.T) {
 
 	assert.Equal(t, http.StatusOK, w.Code)
 	assert.Contains(t, w.Body.String(), "page intentionally blank")
-	assert.False(t, strings.Contains(w.Body.String(), "<a href"))
+	assert.NotContains(t, w.Body.String(), "<a href")
 }

--- a/internal/kromgo/instant.go
+++ b/internal/kromgo/instant.go
@@ -1,0 +1,112 @@
+package kromgo
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"time"
+
+	v1 "github.com/prometheus/client_golang/api/prometheus/v1"
+	"github.com/prometheus/common/model"
+)
+
+// handleInstant serves the json, raw, and badge formats. The value comes from an
+// instant query, or a reduced range query when the metric's type is "range".
+func (h *Handler) handleInstant(w http.ResponseWriter, r *http.Request, metric *resolvedMetric, format string, log *slog.Logger) {
+	value, err := h.queryValue(r.Context(), metric)
+	if err != nil {
+		log.Error("error executing metric query", "error", err)
+		writeError(w, metric.Name, "Query Error", http.StatusInternalServerError)
+		return
+	}
+
+	if format == "raw" {
+		if err := writeJSON(w, value); err != nil {
+			log.Error("could not convert query result to json", "error", err)
+			writeError(w, metric.Name, "Query Error", http.StatusInternalServerError)
+		}
+		return
+	}
+
+	vector, ok := value.(model.Vector)
+	if !ok {
+		log.Error("query did not return an instant vector", "type", value.Type().String())
+		writeError(w, metric.Name, "Unexpected result type", http.StatusInternalServerError)
+		return
+	}
+
+	if len(vector) == 0 {
+		// No data: report it without evaluating the expressions (no result/labels).
+		if err := writeJSON(w, EndpointResponse{SchemaVersion: 1, Label: metricTitle(metric), Message: "metric returned no data"}); err != nil {
+			log.Error("error writing no-data response", "error", err)
+			writeError(w, metric.Name, "Error", http.StatusInternalServerError)
+		}
+		return
+	}
+
+	message, color, ok := h.evalDisplay(metric, vector[0], log)
+	if !ok {
+		writeError(w, metric.Name, "Expression Error", http.StatusInternalServerError)
+		return
+	}
+	title := metricTitle(metric)
+
+	if format == "badge" {
+		h.badges.write(w, r.URL.Query().Get("style"), title, message, color)
+		return
+	}
+
+	resp := EndpointResponse{
+		SchemaVersion: 1,
+		Label:         title,
+		Message:       message,
+		Color:         color,               // omitted when empty
+		CacheSeconds:  metric.cacheSeconds, // shields.io honors this; omitted when 0
+	}
+	if err := writeJSON(w, resp); err != nil {
+		log.Error("error converting data to json response", "error", err)
+		writeError(w, metric.Name, "Error", http.StatusInternalServerError)
+	}
+}
+
+// evalDisplay evaluates the metric's value and color CEL expressions against a
+// sample. ok is false only if the value expression errors (caller returns 500);
+// a failing color expression is logged and treated as no color.
+func (h *Handler) evalDisplay(metric *resolvedMetric, sample *model.Sample, log *slog.Logger) (message, color string, ok bool) {
+	result := float64(sample.Value)
+	labels := labelMap(sample.Metric)
+
+	message, err := evalStringExpr(metric.valueProg, result, labels)
+	if err != nil {
+		log.Error("value expression failed", "error", err)
+		return "", "", false
+	}
+	if metric.colorProg != nil {
+		if color, err = evalStringExpr(metric.colorProg, result, labels); err != nil {
+			log.Error("color expression failed", "error", err) // degrade to no color
+			color = ""
+		}
+	}
+	return message, color, true
+}
+
+// queryValue computes the metric's instant value: an instant query for the default
+// type, or a range query reduced to one value per series for type: range.
+func (h *Handler) queryValue(ctx context.Context, metric *resolvedMetric) (model.Value, error) {
+	rq := metric.rangeQuery
+	if rq == nil {
+		return h.prom.Query(ctx, metric.Query, time.Now())
+	}
+
+	end := time.Now().Add(-rq.offset)
+	value, err := h.prom.QueryRange(ctx, metric.Query, v1.Range{Start: end.Add(-rq.last), End: end, Step: rq.step})
+	if err != nil {
+		return nil, err
+	}
+	matrix, ok := value.(model.Matrix)
+	if !ok {
+		return nil, fmt.Errorf("range query returned %s, want matrix", value.Type())
+	}
+	return reduceMatrix(matrix, rq.reduce), nil
+}

--- a/internal/kromgo/metric.go
+++ b/internal/kromgo/metric.go
@@ -122,6 +122,14 @@ func autoStep(window time.Duration) time.Duration {
 	return max(window/100, minRangeStep)
 }
 
+// metricTitle returns the display title for a metric (its Title, falling back to Name).
+func metricTitle(metric *resolvedMetric) string {
+	if metric.Title != "" {
+		return metric.Title
+	}
+	return metric.Name
+}
+
 // effectiveMaxDuration returns the metric's timeseries max-duration string (per-metric
 // override, else default), or "" when neither is set (caller uses the built-in default).
 func effectiveMaxDuration(m config.Metric, cfg config.KromgoConfig) string {

--- a/internal/kromgo/response.go
+++ b/internal/kromgo/response.go
@@ -16,6 +16,21 @@ type EndpointResponse struct {
 	CacheSeconds  int    `json:"cacheSeconds,omitempty"`
 }
 
+func writeJSON(w http.ResponseWriter, v any) error {
+	body, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	_, _ = w.Write(body)
+	return nil
+}
+
+func writeSVG(w http.ResponseWriter, svg []byte) {
+	w.Header().Set("Content-Type", "image/svg+xml")
+	_, _ = w.Write(svg)
+}
+
 // writeError writes a shields.io-compatible error response with the given status code.
 // Errors are never cached, even if a caller set a Cache-Control header earlier.
 func writeError(w http.ResponseWriter, metric, reason string, code int) {

--- a/internal/kromgo/timeseries.go
+++ b/internal/kromgo/timeseries.go
@@ -1,0 +1,118 @@
+package kromgo
+
+import (
+	"log/slog"
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/home-operations/kromgo/internal/config"
+	v1 "github.com/prometheus/client_golang/api/prometheus/v1"
+	"github.com/prometheus/common/model"
+)
+
+// The helpers below are the windowed range-query foundation shared by the history
+// and chart output formats: parameter parsing, access/window validation, and the
+// range query itself.
+
+var (
+	errStartAfterEnd       = &historyParamError{"start must be before end"}
+	errNonPositiveDuration = &historyParamError{"last must be a positive duration"}
+)
+
+type historyParamError struct{ msg string }
+
+func (e *historyParamError) Error() string { return e.msg }
+
+func parseTimeParam(s string) (time.Time, error) {
+	// Try Unix timestamp (integer) first, then fall back to RFC3339.
+	if ts, err := strconv.ParseInt(s, 10, 64); err == nil {
+		return time.Unix(ts, 0), nil
+	}
+	return time.Parse(time.RFC3339, s)
+}
+
+func parseHistoryParams(r *http.Request) (start, end time.Time, step time.Duration, err error) {
+	now := time.Now()
+	q := r.URL.Query()
+
+	// last=7d is shorthand for start=now-7d&end=now.
+	if s := q.Get("last"); s != "" {
+		d, derr := config.ParseDuration(s)
+		if derr != nil {
+			return start, end, step, derr
+		}
+		if d <= 0 {
+			return start, end, step, errNonPositiveDuration
+		}
+		end, start = now, now.Add(-d)
+	} else {
+		end = now
+		if s := q.Get("end"); s != "" {
+			if end, err = parseTimeParam(s); err != nil {
+				return start, end, step, err
+			}
+		}
+
+		start = end.Add(-1 * time.Hour)
+		if s := q.Get("start"); s != "" {
+			if start, err = parseTimeParam(s); err != nil {
+				return start, end, step, err
+			}
+		}
+
+		if start.After(end) {
+			return start, end, step, errStartAfterEnd
+		}
+	}
+
+	step = autoStep(end.Sub(start))
+	if s := q.Get("step"); s != "" {
+		if step, err = config.ParseDuration(s); err != nil {
+			return start, end, step, err
+		}
+		step = max(step, minRangeStep)
+	}
+
+	return start, end, step, nil
+}
+
+// validateHistoryAccess checks access control, parses time parameters, and enforces the
+// max duration cap. Returns ok=false if an error response was already written.
+func (h *Handler) validateHistoryAccess(w http.ResponseWriter, r *http.Request, metric *resolvedMetric) (start, end time.Time, step time.Duration, ok bool) {
+	if !metric.historyEnabled {
+		writeError(w, metric.Name, "History not enabled for this metric", http.StatusForbidden)
+		return start, end, step, false
+	}
+
+	start, end, step, err := parseHistoryParams(r)
+	if err != nil {
+		writeError(w, metric.Name, "Invalid parameter: "+err.Error(), http.StatusBadRequest)
+		return start, end, step, false
+	}
+
+	if metric.historyMax > 0 && end.Sub(start) > metric.historyMax {
+		writeError(w, metric.Name, "Requested time window exceeds maximum allowed duration", http.StatusBadRequest)
+		return start, end, step, false
+	}
+
+	return start, end, step, true
+}
+
+// queryMatrix runs a range query and asserts the result is a matrix, writing an error
+// response and returning ok=false otherwise.
+func (h *Handler) queryMatrix(w http.ResponseWriter, r *http.Request, metric *resolvedMetric, start, end time.Time, step time.Duration, log *slog.Logger) (model.Matrix, bool) {
+	value, err := h.prom.QueryRange(r.Context(), metric.Query, v1.Range{Start: start, End: end, Step: step})
+	if err != nil {
+		log.Error("error executing range query", "error", err)
+		writeError(w, metric.Name, "Query Error", http.StatusInternalServerError)
+		return nil, false
+	}
+	matrix, ok := value.(model.Matrix)
+	if !ok {
+		log.Error("range query did not return a matrix", "type", value.Type().String())
+		writeError(w, metric.Name, "Unexpected result type", http.StatusInternalServerError)
+		return nil, false
+	}
+	return matrix, true
+}

--- a/internal/promtest/promtest.go
+++ b/internal/promtest/promtest.go
@@ -12,6 +12,15 @@ import (
 	"time"
 )
 
+// Get issues a GET request against h and returns the recorded response.
+func Get(t testing.TB, h http.Handler, target string) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodGet, target, nil)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+	return w
+}
+
 // Sample is one instant-query result: a value and its labels.
 type Sample struct {
 	Value  string

--- a/test/integration/integration_test.go
+++ b/test/integration/integration_test.go
@@ -9,7 +9,6 @@ package integration
 
 import (
 	"net/http"
-	"net/http/httptest"
 	"os"
 	"testing"
 	"time"
@@ -17,6 +16,7 @@ import (
 	"github.com/home-operations/kromgo/internal/config"
 	"github.com/home-operations/kromgo/internal/kromgo"
 	"github.com/home-operations/kromgo/internal/prometheus"
+	"github.com/home-operations/kromgo/internal/promtest"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -42,18 +42,10 @@ func newHandler(t *testing.T) *kromgo.Handler {
 	return h
 }
 
-func get(t *testing.T, h *kromgo.Handler, target string) *httptest.ResponseRecorder {
-	t.Helper()
-	req := httptest.NewRequest(http.MethodGet, target, nil)
-	w := httptest.NewRecorder()
-	h.Mux().ServeHTTP(w, req)
-	return w
-}
-
 func TestIntegration_JSON(t *testing.T) {
 	h := newHandler(t)
 
-	w := get(t, h, "/up")
+	w := promtest.Get(t, h.Mux(), "/up")
 
 	assert.Equal(t, http.StatusOK, w.Code)
 	assert.Equal(t, "application/json", w.Header().Get("Content-Type"))
@@ -63,7 +55,7 @@ func TestIntegration_JSON(t *testing.T) {
 func TestIntegration_History(t *testing.T) {
 	h := newHandler(t)
 
-	w := get(t, h, "/up?format=history&last=1h")
+	w := promtest.Get(t, h.Mux(), "/up?format=history&last=1h")
 
 	assert.Equal(t, http.StatusOK, w.Code)
 	assert.Contains(t, w.Body.String(), `"metric":"up"`)


### PR DESCRIPTION
## Summary

A no-behavior-change cleanliness pass over the codebase.

- **Restructure `internal/kromgo`** so each file owns one concern:
  - `instant.go` — the json/raw/badge value path (`handleInstant`/`evalDisplay`/`queryValue`)
  - `timeseries.go` — the windowed range-query plumbing shared by history **and** chart (`parseHistoryParams`/`validateHistoryAccess`/`queryMatrix` + param errors)
  - `response.go` — the response writers + shields.io envelope, absorbing `errors.go`
  - `handler.go` is now just wiring + dispatch; `metricTitle` moved next to `resolvedMetric`
- **Share the duplicated test HTTP helper** as `promtest.Get`, replacing the identical `doGet`/`get` copies.
- **Convert remaining hand-written assertions to testify + table-driven** form (`duration`, `history`, `index`, `chart` tests).
- **Two single-pass micro-opts**: chart min/max + point building, and custom-unit duration parsing.

Net: ~770 deletions / ~560 insertions, mostly from collapsing repetitive tests.

## Test plan

- [x] `go build ./...`
- [x] `mise run lint` → 0 issues (incl. `unused`, confirming no dead code)
- [x] `mise run test` → all pass (77.5% total coverage)
- [x] `mise run test-e2e` → passes every output format (json/raw/badge/history/chart/index/404)
- [x] `mise run generate` → `config.schema.json` unchanged (no config-model change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)