### PR TITLE
refactor: request-scoped logging and comprehensive test cleanup

### DIFF
--- a/cmd/kromgo/main.go
+++ b/cmd/kromgo/main.go
@@ -8,11 +8,11 @@ import (
 	"log/slog"
 	"os"
 	"os/signal"
-	"strings"
 	"syscall"
 
 	"github.com/home-operations/kromgo/internal/config"
 	"github.com/home-operations/kromgo/internal/kromgo"
+	"github.com/home-operations/kromgo/internal/logging"
 	"github.com/home-operations/kromgo/internal/prometheus"
 	"github.com/home-operations/kromgo/internal/server"
 )
@@ -33,7 +33,7 @@ func run() error {
 	configPath := flag.String("config", "", "Path to the YAML config file")
 	flag.Parse()
 
-	initLogger()
+	logging.Init()
 	slog.Info("starting kromgo", "version", Version, "gitsha", Gitsha)
 
 	cfg, err := config.Load(*configPath)
@@ -61,24 +61,4 @@ func run() error {
 	defer stop()
 
 	return server.Run(ctx, sc, handler.Mux())
-}
-
-// initLogger configures the default slog logger from LOG_LEVEL and LOG_FORMAT.
-func initLogger() {
-	level := slog.LevelInfo
-	switch strings.ToLower(os.Getenv("LOG_LEVEL")) {
-	case "debug":
-		level = slog.LevelDebug
-	case "warn":
-		level = slog.LevelWarn
-	case "error":
-		level = slog.LevelError
-	}
-
-	opts := &slog.HandlerOptions{Level: level}
-	var handler slog.Handler = slog.NewJSONHandler(os.Stdout, opts)
-	if strings.EqualFold(os.Getenv("LOG_FORMAT"), "text") {
-		handler = slog.NewTextHandler(os.Stdout, opts)
-	}
-	slog.SetDefault(slog.New(handler))
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -18,6 +18,7 @@ func writeConfig(t *testing.T, body string) string {
 }
 
 func TestLoad_Valid(t *testing.T) {
+	t.Parallel()
 	path := writeConfig(t, `
 prometheus: http://prom:9090
 gallery:
@@ -55,22 +56,26 @@ graphs:
 }
 
 func TestLoad_MissingFile(t *testing.T) {
+	t.Parallel()
 	_, err := Load(filepath.Join(t.TempDir(), "nope.yaml"))
 	assert.Error(t, err)
 }
 
 func TestLoad_InvalidYAML(t *testing.T) {
+	t.Parallel()
 	_, err := Load(writeConfig(t, "badges: [: bad"))
 	assert.Error(t, err)
 }
 
 func TestLoad_RejectsUnknownKey(t *testing.T) {
+	t.Parallel()
 	// A non-legacy typo'd key must error under strict decoding.
 	_, err := Load(writeConfig(t, "badges: []\nbogus: true\n"))
 	assert.Error(t, err)
 }
 
 func TestLoad_LegacyConfigErrors(t *testing.T) {
+	t.Parallel()
 	// A pre-0.12 config (top-level metrics:) gets a pointed migration error.
 	_, err := Load(writeConfig(t, "metrics:\n  - name: cpu\n    query: q\n"))
 	require.Error(t, err)
@@ -78,22 +83,26 @@ func TestLoad_LegacyConfigErrors(t *testing.T) {
 }
 
 func TestLoad_InvalidDuration(t *testing.T) {
+	t.Parallel()
 	_, err := Load(writeConfig(t, "defaults:\n  graph:\n    maxDuration: bogus\n"))
 	assert.Error(t, err)
 }
 
 func TestLoad_DuplicateID(t *testing.T) {
+	t.Parallel()
 	_, err := Load(writeConfig(t, "badges:\n  - id: cpu\n    query: q\n  - id: cpu\n    query: q\n"))
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "duplicate")
 }
 
 func TestLoad_RangeBadgeRequiresLast(t *testing.T) {
+	t.Parallel()
 	_, err := Load(writeConfig(t, "badges:\n  - id: cpu\n    query: q\n    type: range\n"))
 	assert.Error(t, err)
 }
 
 func TestLoad_InvalidID(t *testing.T) {
+	t.Parallel()
 	// ids are URL path segments and gallery Markdown; reject unsafe characters.
 	_, err := Load(writeConfig(t, "badges:\n  - id: a/b\n    query: q\n"))
 	require.Error(t, err)

--- a/internal/config/duration_test.go
+++ b/internal/config/duration_test.go
@@ -9,6 +9,7 @@ import (
 )
 
 func TestParseDuration(t *testing.T) {
+	t.Parallel()
 	cases := []struct {
 		name    string
 		in      string
@@ -29,6 +30,7 @@ func TestParseDuration(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 			got, err := ParseDuration(tc.in)
 			if tc.wantErr {
 				assert.Error(t, err)
@@ -41,6 +43,7 @@ func TestParseDuration(t *testing.T) {
 }
 
 func TestValidate_Durations(t *testing.T) {
+	t.Parallel()
 	cases := []struct {
 		name    string
 		cfg     KromgoConfig
@@ -70,6 +73,7 @@ func TestValidate_Durations(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 			err := tc.cfg.validate()
 			if tc.wantErr {
 				assert.Error(t, err)
@@ -81,6 +85,7 @@ func TestValidate_Durations(t *testing.T) {
 }
 
 func TestValidate_RangeType(t *testing.T) {
+	t.Parallel()
 	badge := func(b Badge) KromgoConfig { return KromgoConfig{Badges: []Badge{b}} }
 	cases := []struct {
 		name    string
@@ -98,6 +103,7 @@ func TestValidate_RangeType(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 			err := tc.cfg.validate()
 			if tc.wantErr {
 				assert.Error(t, err)

--- a/internal/kromgo/badge_test.go
+++ b/internal/kromgo/badge_test.go
@@ -10,6 +10,7 @@ import (
 )
 
 func TestColorNameToHex(t *testing.T) {
+	t.Parallel()
 	cases := map[string]string{
 		"":          "#007ec6", // default blue
 		"blue":      "#007ec6",
@@ -22,12 +23,14 @@ func TestColorNameToHex(t *testing.T) {
 	}
 	for in, want := range cases {
 		t.Run(in, func(t *testing.T) {
+			t.Parallel()
 			assert.Equal(t, want, colorNameToHex(in))
 		})
 	}
 }
 
 func TestNewBadgeRenderer_DefaultFont(t *testing.T) {
+	t.Parallel()
 	r, err := newBadgeRenderer(config.BadgeDefaults{})
 	require.NoError(t, err)
 	require.NotNil(t, r)
@@ -39,17 +42,20 @@ func TestNewBadgeRenderer_DefaultFont(t *testing.T) {
 }
 
 func TestNewBadgeRenderer_UnknownFont(t *testing.T) {
+	t.Parallel()
 	_, err := newBadgeRenderer(config.BadgeDefaults{Font: "not-a-font"})
 	assert.Error(t, err)
 }
 
 func TestNewBadgeRenderer_NamedFont(t *testing.T) {
+	t.Parallel()
 	r, err := newBadgeRenderer(config.BadgeDefaults{Font: "go-bold"})
 	require.NoError(t, err)
 	require.NotNil(t, r)
 }
 
 func TestBadgeRender_Icon(t *testing.T) {
+	t.Parallel()
 	r, err := newBadgeRenderer(config.BadgeDefaults{})
 	require.NoError(t, err)
 
@@ -62,6 +68,7 @@ func TestBadgeRender_Icon(t *testing.T) {
 }
 
 func TestResolveIcon(t *testing.T) {
+	t.Parallel()
 	path, err := resolveIcon("mdi:server-outline")
 	require.NoError(t, err)
 	assert.True(t, strings.HasPrefix(path, "M"))
@@ -83,6 +90,7 @@ func TestResolveIcon(t *testing.T) {
 }
 
 func TestMDIIconsEmbedded(t *testing.T) {
+	t.Parallel()
 	// The full Material Design Icons set is embedded and decodes cleanly.
 	assert.Greater(t, len(mdiIcons()), 7000, "full MDI set should be embedded")
 }

--- a/internal/kromgo/chart_test.go
+++ b/internal/kromgo/chart_test.go
@@ -31,6 +31,7 @@ func makeMatrix(series [][]float64) model.Matrix {
 }
 
 func TestRenderChart_SVG(t *testing.T) {
+	t.Parallel()
 	svg, err := renderChart(makeMatrix([][]float64{{10, 25, 15, 40, 30}}),
 		chartParams{width: 400, height: 150, legend: true, format: formatSVG})
 	require.NoError(t, err)
@@ -39,6 +40,7 @@ func TestRenderChart_SVG(t *testing.T) {
 }
 
 func TestRenderChart_Title(t *testing.T) {
+	t.Parallel()
 	svg, err := renderChart(makeMatrix([][]float64{{1, 2, 3}}),
 		chartParams{width: 400, height: 150, title: "CPU usage", format: formatSVG})
 	require.NoError(t, err)
@@ -46,6 +48,7 @@ func TestRenderChart_Title(t *testing.T) {
 }
 
 func TestRenderChart_PNG(t *testing.T) {
+	t.Parallel()
 	png, err := renderChart(makeMatrix([][]float64{{10, 25, 15, 40, 30}}),
 		chartParams{width: 400, height: 150, format: formatPNG})
 	require.NoError(t, err)
@@ -55,6 +58,7 @@ func TestRenderChart_PNG(t *testing.T) {
 }
 
 func TestRenderChart_NaNAndInfBecomeGaps(t *testing.T) {
+	t.Parallel()
 	// Non-finite samples must not produce a broken image or literal NaN/Inf text.
 	matrix := makeMatrix([][]float64{{10, 20, 30, 40}})
 	matrix[0].Values[1].Value = model.SampleValue(math.NaN())
@@ -67,6 +71,7 @@ func TestRenderChart_NaNAndInfBecomeGaps(t *testing.T) {
 }
 
 func TestRenderChart_Theme(t *testing.T) {
+	t.Parallel()
 	// A custom theme's background color should appear in the rendered SVG.
 	matrix := makeMatrix([][]float64{{1, 2, 3}})
 	svg, err := renderChart(matrix, chartParams{width: 400, height: 150, theme: "dracula", format: formatSVG})
@@ -76,6 +81,7 @@ func TestRenderChart_Theme(t *testing.T) {
 }
 
 func TestSeriesLabel(t *testing.T) {
+	t.Parallel()
 	stream := &model.SampleStream{Metric: model.Metric{
 		"__name__": "x", "instance": "node-1", "job": "kube",
 	}}
@@ -87,6 +93,7 @@ func TestSeriesLabel(t *testing.T) {
 }
 
 func TestChartParams_WithOverrides(t *testing.T) {
+	t.Parallel()
 	base := chartParams{width: 300, height: 80, legend: true, theme: "dark", format: formatSVG}
 
 	req := httptest.NewRequest(http.MethodGet,
@@ -106,8 +113,10 @@ func TestChartParams_WithOverrides(t *testing.T) {
 }
 
 func TestResolveGraphFont(t *testing.T) {
+	t.Parallel()
 	for _, name := range []string{"", "roboto", "notosans", "go-regular", "go-bold", "go-medium", "go-mono"} {
 		t.Run("ok/"+name, func(t *testing.T) {
+			t.Parallel()
 			f, err := resolveGraphFont(name)
 			require.NoError(t, err)
 			if name == "" {
@@ -118,11 +127,15 @@ func TestResolveGraphFont(t *testing.T) {
 		})
 	}
 	// An unknown font name errors (no disk fallback).
-	_, err := resolveGraphFont("not-a-font")
-	assert.Error(t, err)
+	t.Run("unknown errors", func(t *testing.T) {
+		t.Parallel()
+		_, err := resolveGraphFont("not-a-font")
+		assert.Error(t, err)
+	})
 }
 
 func TestRenderChart_CustomFont(t *testing.T) {
+	t.Parallel()
 	font, err := resolveGraphFont("go-bold")
 	require.NoError(t, err)
 	svg, err := renderChart(makeMatrix([][]float64{{1, 2, 3}}),
@@ -132,10 +145,22 @@ func TestRenderChart_CustomFont(t *testing.T) {
 }
 
 func TestValidTheme(t *testing.T) {
-	assert.True(t, validTheme("dark"))             // built-in
-	assert.True(t, validTheme("grafana"))          // built-in
-	assert.True(t, validTheme("dracula"))          // custom
-	assert.True(t, validTheme("catppuccin-mocha")) // custom
-	assert.False(t, validTheme("nope"))
-	assert.False(t, validTheme(""))
+	t.Parallel()
+	cases := []struct {
+		theme string
+		want  bool
+	}{
+		{"dark", true},             // built-in
+		{"grafana", true},          // built-in
+		{"dracula", true},          // custom
+		{"catppuccin-mocha", true}, // custom
+		{"nope", false},
+		{"", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.theme, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tc.want, validTheme(tc.theme))
+		})
+	}
 }

--- a/internal/kromgo/expr_test.go
+++ b/internal/kromgo/expr_test.go
@@ -18,6 +18,7 @@ func eval(t *testing.T, src string, result float64, labels map[string]string) (s
 }
 
 func TestCEL_Expressions(t *testing.T) {
+	t.Parallel()
 	cases := []struct {
 		name   string
 		src    string
@@ -51,6 +52,7 @@ func TestCEL_Expressions(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 			got, err := eval(t, tc.src, tc.result, tc.labels)
 			require.NoError(t, err)
 			assert.Equal(t, tc.want, got)
@@ -59,6 +61,7 @@ func TestCEL_Expressions(t *testing.T) {
 }
 
 func TestCEL_CompileRejectsNonString(t *testing.T) {
+	t.Parallel()
 	env, err := newCELEnv()
 	require.NoError(t, err)
 	_, err = compileStringExpr(env, "test", "value", "result") // double, not string
@@ -66,6 +69,7 @@ func TestCEL_CompileRejectsNonString(t *testing.T) {
 }
 
 func TestCEL_NoEnvOrFileAccess(t *testing.T) {
+	t.Parallel()
 	// CEL is sandboxed: there is no env()/readFile()/etc. to leak host state.
 	env, err := newCELEnv()
 	require.NoError(t, err)

--- a/internal/kromgo/formatting_test.go
+++ b/internal/kromgo/formatting_test.go
@@ -6,57 +6,76 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestHumanizeBytes(t *testing.T) {
-	// IEC binary units via go-humanize (spaced).
-	assert.Equal(t, "1.0 KiB", humanizeBytes(1024))
-	assert.Equal(t, "1.5 MiB", humanizeBytes(1572864))
-	assert.Equal(t, "2.0 GiB", humanizeBytes(2147483648))
-	assert.Equal(t, "512 B", humanizeBytes(512))
-}
+const day = 86400.0
 
-func TestHumanizeSIBytes(t *testing.T) {
-	assert.Equal(t, "1.0 kB", humanizeSIBytes(1000))
-	assert.Equal(t, "1.5 MB", humanizeSIBytes(1500000))
-}
-
-func TestHumanizeNumber(t *testing.T) {
-	assert.Equal(t, "157,121", humanizeNumber(157121))
-	assert.Equal(t, "1,000,000", humanizeNumber(1000000))
-	assert.Equal(t, "1,234.56", humanizeNumber(1234.56))
-	assert.Equal(t, "-1,234", humanizeNumber(-1234))
-}
-
-func TestHumanizeFloat(t *testing.T) {
-	assert.Equal(t, "200", humanizeFloat(200))
-	assert.Equal(t, "2.5", humanizeFloat(2.50))
-	assert.Equal(t, "2", humanizeFloat(2.0))
-	assert.Equal(t, "1234.567", humanizeFloat(1234.567))
-}
-
-func TestHumanizeDays(t *testing.T) {
-	const day = 86400.0
-	assert.Equal(t, "69d", humanizeDays(69*day))
-	assert.Equal(t, "544d", humanizeDays(544*day))
-	assert.Equal(t, "6769d", humanizeDays(6769*day))
-	assert.Equal(t, "1d", humanizeDays(1.5*day)) // truncates
-	assert.Equal(t, "0d", humanizeDays(3600))    // under a day
-	assert.Equal(t, "0d", humanizeDays(-5))      // clamped
+func TestHumanizers(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name string
+		fn   func(float64) string
+		in   float64
+		want string
+	}{
+		// humanizeBytes: IEC binary units via go-humanize (spaced).
+		{"bytes KiB", humanizeBytes, 1024, "1.0 KiB"},
+		{"bytes MiB", humanizeBytes, 1572864, "1.5 MiB"},
+		{"bytes GiB", humanizeBytes, 2147483648, "2.0 GiB"},
+		{"bytes B", humanizeBytes, 512, "512 B"},
+		// humanizeSIBytes: SI decimal units.
+		{"sibytes kB", humanizeSIBytes, 1000, "1.0 kB"},
+		{"sibytes MB", humanizeSIBytes, 1500000, "1.5 MB"},
+		// humanizeNumber: thousands separators.
+		{"number int", humanizeNumber, 157121, "157,121"},
+		{"number million", humanizeNumber, 1000000, "1,000,000"},
+		{"number float", humanizeNumber, 1234.56, "1,234.56"},
+		{"number negative", humanizeNumber, -1234, "-1,234"},
+		// humanizeFloat: minimal float formatting.
+		{"float int-valued", humanizeFloat, 200, "200"},
+		{"float one decimal", humanizeFloat, 2.50, "2.5"},
+		{"float whole", humanizeFloat, 2.0, "2"},
+		{"float many decimals", humanizeFloat, 1234.567, "1234.567"},
+		// humanizeDays: whole days, truncated and clamped at zero.
+		{"days 69", humanizeDays, 69 * day, "69d"},
+		{"days 544", humanizeDays, 544 * day, "544d"},
+		{"days 6769", humanizeDays, 6769 * day, "6769d"},
+		{"days truncates", humanizeDays, 1.5 * day, "1d"},
+		{"days under a day", humanizeDays, 3600, "0d"},
+		{"days clamped", humanizeDays, -5, "0d"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tc.want, tc.fn(tc.in))
+		})
+	}
 }
 
 func TestHumanizeDuration(t *testing.T) {
-	const day = 86400.0
-	// Sub-day: fine-grained, top-3 significant units.
-	assert.Equal(t, "45s", humanizeDuration(45))
-	assert.Equal(t, "1m30s", humanizeDuration(90))
-	assert.Equal(t, "2h30m", humanizeDuration(9000)) // trailing 0s dropped
-	assert.Equal(t, "1d2h3m", humanizeDuration(93780))
-	// Long spans roll up to months ("mo") and years; sub-day noise drops off.
-	assert.Equal(t, "1y3mo12d", humanizeDuration(467*day))   // 365 + 3*30 + 12
-	assert.Equal(t, "5y8mo12d", humanizeDuration(179452910)) // 5y8mo12d1m50s, trimmed to top 3
-	assert.Equal(t, "1y", humanizeDuration(365*day))         // exact year
-	assert.Equal(t, "1mo5d", humanizeDuration(35*day))       // 1 month 5 days
-	assert.Equal(t, "5d4h", humanizeDuration(5*day+4*3600))  // skips zero minutes/seconds
-	// Edges.
-	assert.Equal(t, "0s", humanizeDuration(0))
-	assert.Equal(t, "0s", humanizeDuration(-5)) // clamped
+	t.Parallel()
+	cases := []struct {
+		name string
+		in   float64
+		want string
+	}{
+		// Sub-day: fine-grained, top-3 significant units.
+		{"seconds", 45, "45s"},
+		{"minutes", 90, "1m30s"},
+		{"trailing zeros dropped", 9000, "2h30m"},
+		{"day hour minute", 93780, "1d2h3m"},
+		// Long spans roll up to months ("mo") and years; sub-day noise drops off.
+		{"year months days", 467 * day, "1y3mo12d"},  // 365 + 3*30 + 12
+		{"trimmed to top 3", 179452910, "5y8mo12d"},  // 5y8mo12d1m50s
+		{"exact year", 365 * day, "1y"},              // exact year
+		{"month and days", 35 * day, "1mo5d"},        // 1 month 5 days
+		{"skips zero units", 5*day + 4*3600, "5d4h"}, // skips zero minutes/seconds
+		// Edges.
+		{"zero", 0, "0s"},
+		{"negative clamped", -5, "0s"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tc.want, humanizeDuration(tc.in))
+		})
+	}
 }

--- a/internal/kromgo/graph.go
+++ b/internal/kromgo/graph.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/home-operations/kromgo/internal/logging"
 	"github.com/prometheus/common/model"
 )
 
@@ -43,7 +44,7 @@ func (h *Handler) serveGraph(w http.ResponseWriter, r *http.Request) {
 
 	metricLabel := "unknown"
 	defer func() { requestsTotal.WithLabelValues("graph", metricLabel, format).Inc() }()
-	log := requestLogger(r, "graph", id, format)
+	log := logging.FromContext(r.Context()).With("kind", "graph", "id", id, "format", format)
 
 	graph, ok := h.graphs[id]
 	if !ok {

--- a/internal/kromgo/graph_query.go
+++ b/internal/kromgo/graph_query.go
@@ -1,6 +1,7 @@
 package kromgo
 
 import (
+	"errors"
 	"log/slog"
 	"net/http"
 	"strconv"
@@ -15,13 +16,9 @@ import (
 // output formats: parameter parsing, window validation, and the range query itself.
 
 var (
-	errStartAfterEnd       = &graphParamError{"start must be before end"}
-	errNonPositiveDuration = &graphParamError{"last must be a positive duration"}
+	errStartAfterEnd       = errors.New("start must be before end")
+	errNonPositiveDuration = errors.New("last must be a positive duration")
 )
-
-type graphParamError struct{ msg string }
-
-func (e *graphParamError) Error() string { return e.msg }
 
 func parseTimeParam(s string) (time.Time, error) {
 	// Try Unix timestamp (integer) first, then fall back to RFC3339.

--- a/internal/kromgo/graph_query_test.go
+++ b/internal/kromgo/graph_query_test.go
@@ -20,6 +20,7 @@ func makeRequest(params map[string]string) *http.Request {
 }
 
 func TestParseGraphParams_Valid(t *testing.T) {
+	t.Parallel()
 	// wantStart/wantEnd/wantStep of 0 mean "don't assert this field".
 	cases := []struct {
 		name      string
@@ -38,6 +39,7 @@ func TestParseGraphParams_Valid(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 			start, end, step, err := parseGraphParams(makeRequest(tc.params))
 			require.NoError(t, err)
 			if tc.wantStart != 0 {
@@ -54,6 +56,7 @@ func TestParseGraphParams_Valid(t *testing.T) {
 }
 
 func TestParseGraphParams_DefaultWindow(t *testing.T) {
+	t.Parallel()
 	before := time.Now()
 	start, end, step, err := parseGraphParams(makeRequest(nil))
 	require.NoError(t, err)
@@ -63,6 +66,7 @@ func TestParseGraphParams_DefaultWindow(t *testing.T) {
 }
 
 func TestParseGraphParams_Errors(t *testing.T) {
+	t.Parallel()
 	cases := []struct {
 		name     string
 		params   map[string]string
@@ -77,6 +81,7 @@ func TestParseGraphParams_Errors(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 			_, _, _, err := parseGraphParams(makeRequest(tc.params))
 			require.Error(t, err)
 			if tc.sentinel != nil {
@@ -87,6 +92,7 @@ func TestParseGraphParams_Errors(t *testing.T) {
 }
 
 func TestParseTimeParam(t *testing.T) {
+	t.Parallel()
 	cases := []struct {
 		name     string
 		in       string
@@ -99,6 +105,7 @@ func TestParseTimeParam(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 			ts, err := parseTimeParam(tc.in)
 			if tc.wantErr {
 				assert.Error(t, err)
@@ -111,6 +118,7 @@ func TestParseTimeParam(t *testing.T) {
 }
 
 func TestResolveGraph_MaxDuration(t *testing.T) {
+	t.Parallel()
 	cases := []struct {
 		name  string
 		graph config.Graph
@@ -124,6 +132,7 @@ func TestResolveGraph_MaxDuration(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 			rg, err := resolveGraph(tc.graph, tc.def)
 			require.NoError(t, err)
 			assert.Equal(t, tc.want, rg.maxDuration)
@@ -132,12 +141,14 @@ func TestResolveGraph_MaxDuration(t *testing.T) {
 }
 
 func TestResolveGraph_InvalidTheme(t *testing.T) {
+	t.Parallel()
 	_, err := resolveGraph(config.Graph{ID: "t", Query: "q", Theme: "nope"}, config.Defaults{})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "theme")
 }
 
 func TestResolveGraph_DefaultParams(t *testing.T) {
+	t.Parallel()
 	rg, err := resolveGraph(config.Graph{ID: "t"}, config.Defaults{})
 	require.NoError(t, err)
 	assert.Equal(t, defaultGraphWidth, rg.defaults.width)
@@ -146,6 +157,7 @@ func TestResolveGraph_DefaultParams(t *testing.T) {
 }
 
 func TestResolveBadge_InvalidExprFailsFast(t *testing.T) {
+	t.Parallel()
 	env, err := newCELEnv()
 	require.NoError(t, err)
 	cases := map[string]config.Badge{
@@ -155,6 +167,7 @@ func TestResolveBadge_InvalidExprFailsFast(t *testing.T) {
 	}
 	for name, b := range cases {
 		t.Run(name, func(t *testing.T) {
+			t.Parallel()
 			_, err := resolveBadge(b, config.Defaults{}, env)
 			assert.Error(t, err)
 		})
@@ -162,6 +175,7 @@ func TestResolveBadge_InvalidExprFailsFast(t *testing.T) {
 }
 
 func TestResolveBadge_Style(t *testing.T) {
+	t.Parallel()
 	env, err := newCELEnv()
 	require.NoError(t, err)
 

--- a/internal/kromgo/handler.go
+++ b/internal/kromgo/handler.go
@@ -4,7 +4,6 @@ package kromgo
 
 import (
 	"fmt"
-	"log/slog"
 	"net/http"
 
 	"github.com/home-operations/kromgo/internal/config"
@@ -73,14 +72,6 @@ func (h *Handler) Mux() http.Handler {
 	return mux
 }
 
-// setCache applies a successful response's cache policy; writeError later overrides
-// it with no-store on failures.
-func setCache(w http.ResponseWriter, cacheSeconds int) {
-	if cacheSeconds > 0 {
-		w.Header().Set("Cache-Control", fmt.Sprintf("public, max-age=%d", cacheSeconds))
-	}
-}
-
 // labelMap converts a Prometheus label set to a plain string map for CEL/JSON use.
 func labelMap(m model.Metric) map[string]string {
 	out := make(map[string]string, len(m))
@@ -88,14 +79,4 @@ func labelMap(m model.Metric) map[string]string {
 		out[string(k)] = string(v)
 	}
 	return out
-}
-
-func requestLogger(r *http.Request, kind, id, format string) *slog.Logger {
-	return slog.With(
-		slog.String("method", r.Method),
-		slog.String("path", r.URL.Path),
-		slog.String("kind", kind),
-		slog.String("id", id),
-		slog.String("format", format),
-	)
 }

--- a/internal/kromgo/handler_test.go
+++ b/internal/kromgo/handler_test.go
@@ -52,8 +52,17 @@ func counterValue(t *testing.T, c promclient.Counter) float64 {
 	return m.GetCounter().GetValue()
 }
 
+// assertSVGOK asserts a 200 SVG image response.
+func assertSVGOK(t *testing.T, w *httptest.ResponseRecorder) {
+	t.Helper()
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, "image/svg+xml", w.Header().Get("Content-Type"))
+	assert.True(t, strings.HasPrefix(w.Body.String(), "<svg"))
+}
+
 // An unknown badge path must fold into the bounded ("badge","unknown","svg")
-// counter series rather than minting new label values.
+// counter series rather than minting new label values. Kept serial (no t.Parallel):
+// the before/after delta is measured before the package's parallel tests run.
 func TestServeBadge_CounterCardinalityBounded(t *testing.T) {
 	srv := mockProm(t, "1", nil)
 	h := newHandlerForTest(t, baseConfig(), srv.URL)
@@ -66,64 +75,59 @@ func TestServeBadge_CounterCardinalityBounded(t *testing.T) {
 	assert.Equal(t, before+2, after)
 }
 
-func TestServeBadge_SVGDefault(t *testing.T) {
+// TestServeBadge_Output covers the badge output formats that share the standard
+// config and instant value (17.5, labelled job=node).
+func TestServeBadge_Output(t *testing.T) {
+	t.Parallel()
 	srv := mockProm(t, "17.5", nil)
 	h := newHandlerForTest(t, baseConfig(), srv.URL)
 
-	w := promtest.Get(t, h.Mux(), "/badges/cpu")
-
-	assert.Equal(t, http.StatusOK, w.Code)
-	assert.Equal(t, "image/svg+xml", w.Header().Get("Content-Type"))
-	assert.True(t, strings.HasPrefix(w.Body.String(), "<svg"))
-}
-
-func TestServeBadge_Shields(t *testing.T) {
-	srv := mockProm(t, "17.5", nil)
-	h := newHandlerForTest(t, baseConfig(), srv.URL)
-
-	w := promtest.Get(t, h.Mux(), "/badges/cpu?format=shields")
-
-	assert.Equal(t, http.StatusOK, w.Code)
-	assert.Equal(t, "application/json", w.Header().Get("Content-Type"))
-	var body map[string]any
-	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &body))
-	assert.EqualValues(t, 1, body["schemaVersion"])
-	assert.Equal(t, "cpu", body["label"])
-	assert.Equal(t, "17.5%", body["message"])
-	assert.Equal(t, "green", body["color"])
-}
-
-func TestServeBadge_JSON(t *testing.T) {
-	srv := mockProm(t, "17.5", nil)
-	h := newHandlerForTest(t, baseConfig(), srv.URL)
-
-	w := promtest.Get(t, h.Mux(), "/badges/cpu?format=json")
-
-	assert.Equal(t, http.StatusOK, w.Code)
-	assert.Equal(t, "application/json", w.Header().Get("Content-Type"))
-	var body BadgeJSON
-	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &body))
-	assert.Equal(t, "cpu", body.ID)
-	assert.Equal(t, "17.5%", body.Value)
-	assert.Equal(t, "green", body.Color)
-	require.NotNil(t, body.Result)
-	assert.InDelta(t, 17.5, *body.Result, 0.001)
-	assert.Equal(t, "node", body.Labels["job"])
-}
-
-func TestServeBadge_Styles(t *testing.T) {
-	srv := mockProm(t, "17.5", nil)
-	h := newHandlerForTest(t, baseConfig(), srv.URL)
-
-	for _, style := range []string{"", "flat-square", "plastic"} {
-		w := promtest.Get(t, h.Mux(), "/badges/cpu?style="+style)
-		assert.Equal(t, http.StatusOK, w.Code, "style=%q", style)
-		assert.Equal(t, "image/svg+xml", w.Header().Get("Content-Type"), "style=%q", style)
-		assert.True(t, strings.HasPrefix(w.Body.String(), "<svg"), "style=%q", style)
+	cases := []struct {
+		name  string
+		path  string
+		check func(t *testing.T, w *httptest.ResponseRecorder)
+	}{
+		{"svg default", "/badges/cpu", assertSVGOK},
+		{"style flat-square", "/badges/cpu?style=flat-square", assertSVGOK},
+		{"style plastic", "/badges/cpu?style=plastic", assertSVGOK},
+		{"unknown style falls back to svg", "/badges/cpu?style=", assertSVGOK},
+		{"shields json", "/badges/cpu?format=shields", func(t *testing.T, w *httptest.ResponseRecorder) {
+			assert.Equal(t, http.StatusOK, w.Code)
+			assert.Equal(t, "application/json", w.Header().Get("Content-Type"))
+			var body map[string]any
+			require.NoError(t, json.Unmarshal(w.Body.Bytes(), &body))
+			assert.EqualValues(t, 1, body["schemaVersion"])
+			assert.Equal(t, "cpu", body["label"])
+			assert.Equal(t, "17.5%", body["message"])
+			assert.Equal(t, "green", body["color"])
+		}},
+		{"native json", "/badges/cpu?format=json", func(t *testing.T, w *httptest.ResponseRecorder) {
+			assert.Equal(t, http.StatusOK, w.Code)
+			assert.Equal(t, "application/json", w.Header().Get("Content-Type"))
+			var body BadgeJSON
+			require.NoError(t, json.Unmarshal(w.Body.Bytes(), &body))
+			assert.Equal(t, "cpu", body.ID)
+			assert.Equal(t, "17.5%", body.Value)
+			assert.Equal(t, "green", body.Color)
+			require.NotNil(t, body.Result)
+			assert.InDelta(t, 17.5, *body.Result, 0.001)
+			assert.Equal(t, "node", body.Labels["job"])
+		}},
+		{"not found", "/badges/does-not-exist", func(t *testing.T, w *httptest.ResponseRecorder) {
+			assert.Equal(t, http.StatusNotFound, w.Code)
+			assert.Contains(t, w.Body.String(), `"isError":true`)
+		}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			tc.check(t, promtest.Get(t, h.Mux(), tc.path))
+		})
 	}
 }
 
 func TestServeBadge_Icon(t *testing.T) {
+	t.Parallel()
 	cfg := config.KromgoConfig{Badges: []config.Badge{{
 		ID: "cpu", Query: "q", Icon: "mdi:server-outline", Value: `string(result) + "%"`,
 	}}}
@@ -138,6 +142,7 @@ func TestServeBadge_Icon(t *testing.T) {
 }
 
 func TestNew_InvalidIconFailsFast(t *testing.T) {
+	t.Parallel()
 	cfg := config.KromgoConfig{Badges: []config.Badge{{ID: "x", Query: "q", Icon: "mdi:does-not-exist"}}}
 	srv := mockProm(t, "1", nil)
 	client, err := prometheus.New(srv.URL, 0)
@@ -147,223 +152,217 @@ func TestNew_InvalidIconFailsFast(t *testing.T) {
 	assert.Error(t, err)
 }
 
-func TestServeBadge_NotFound(t *testing.T) {
-	srv := mockProm(t, "17.5", nil)
-	h := newHandlerForTest(t, baseConfig(), srv.URL)
-
-	w := promtest.Get(t, h.Mux(), "/badges/does-not-exist")
-
-	assert.Equal(t, http.StatusNotFound, w.Code)
-	assert.Contains(t, w.Body.String(), `"isError":true`)
-}
-
 func TestRoutes_NonGETRejected(t *testing.T) {
+	t.Parallel()
 	srv := mockProm(t, "17.5", nil)
 	h := newHandlerForTest(t, baseConfig(), srv.URL)
 
 	for _, method := range []string{http.MethodPost, http.MethodPut, http.MethodDelete} {
-		req := httptest.NewRequest(method, "/badges/cpu", nil)
-		w := httptest.NewRecorder()
-		h.Mux().ServeHTTP(w, req)
-		assert.Equal(t, http.StatusMethodNotAllowed, w.Code, "method=%s", method)
+		t.Run(method, func(t *testing.T) {
+			t.Parallel()
+			req := httptest.NewRequest(method, "/badges/cpu", nil)
+			w := httptest.NewRecorder()
+			h.Mux().ServeHTTP(w, req)
+			assert.Equal(t, http.StatusMethodNotAllowed, w.Code)
+		})
 	}
 }
 
-func TestServeBadge_ValueExpression(t *testing.T) {
-	cfg := config.KromgoConfig{Badges: []config.Badge{{
-		ID: "uptime", Query: "q", Value: "humanizeDuration(result)",
-	}}}
-	srv := mockProm(t, "9000", nil)
-	h := newHandlerForTest(t, cfg, srv.URL)
-
-	w := promtest.Get(t, h.Mux(), "/badges/uptime?format=json")
-
-	assert.Equal(t, http.StatusOK, w.Code)
-	assert.Contains(t, w.Body.String(), `"value":"2h30m"`)
-}
-
-func TestServeBadge_ValueFromLabel(t *testing.T) {
-	srv := promtest.Server(t, promtest.Scalar("0", map[string]string{"version": "v1.2.3"}), nil)
-	cfg := config.KromgoConfig{Badges: []config.Badge{{ID: "ver", Query: "q", Value: `labels["version"]`}}}
-	h := newHandlerForTest(t, cfg, srv.URL)
-
-	w := promtest.Get(t, h.Mux(), "/badges/ver?format=shields")
-
-	assert.Equal(t, http.StatusOK, w.Code)
-	assert.Contains(t, w.Body.String(), `"message":"v1.2.3"`)
-}
-
-func TestServeBadge_ValueExpressionError(t *testing.T) {
-	// Indexing a missing label is a CEL runtime error → 500.
-	srv := promtest.Server(t, promtest.Scalar("0", map[string]string{"other": "x"}), nil)
-	cfg := config.KromgoConfig{Badges: []config.Badge{{ID: "ver", Query: "q", Value: `labels["version"]`}}}
-	h := newHandlerForTest(t, cfg, srv.URL)
-
-	w := promtest.Get(t, h.Mux(), "/badges/ver")
-
-	assert.Equal(t, http.StatusInternalServerError, w.Code)
-	assert.Contains(t, w.Body.String(), `"isError":true`)
-}
-
-func TestServeBadge_StateExpressions(t *testing.T) {
-	cfg := config.KromgoConfig{Badges: []config.Badge{{
-		ID:    "ceph",
-		Query: "q",
-		Value: `result == 0.0 ? "Healthy" : "Critical"`,
-		Color: `result == 0.0 ? "green" : "red"`,
-	}}}
-	srv := mockProm(t, "0", nil)
-	h := newHandlerForTest(t, cfg, srv.URL)
-
-	w := promtest.Get(t, h.Mux(), "/badges/ceph?format=shields")
-
-	assert.Equal(t, http.StatusOK, w.Code)
-	assert.Contains(t, w.Body.String(), `"message":"Healthy"`)
-	assert.Contains(t, w.Body.String(), `"color":"green"`)
-}
-
-func TestServeBadge_EmptyVector_NoData(t *testing.T) {
-	srv := promtest.Server(t, nil, nil) // empty instant vector
-	h := newHandlerForTest(t, baseConfig(), srv.URL)
-
-	w := promtest.Get(t, h.Mux(), "/badges/cpu?format=shields")
-
-	assert.Equal(t, http.StatusOK, w.Code)
-	assert.Contains(t, w.Body.String(), `"message":"no data"`)
-}
-
-func TestServeBadge_RangeType(t *testing.T) {
-	// type: range reduces a range query to one value (avg of 10,20,30 = 20).
-	cfg := config.KromgoConfig{Badges: []config.Badge{{
-		ID:    "cpu_avg",
-		Type:  config.TypeRange,
-		Query: "q",
-		Value: `string(result) + "%"`,
-		Range: &config.RangeQuery{Last: "1h", Reduce: config.ReduceAvg},
-	}}}
-	srv := promtest.Server(t, nil, []float64{10, 20, 30})
-	h := newHandlerForTest(t, cfg, srv.URL)
-
-	w := promtest.Get(t, h.Mux(), "/badges/cpu_avg?format=shields")
-
-	assert.Equal(t, http.StatusOK, w.Code)
-	assert.Contains(t, w.Body.String(), `"message":"20%"`)
-}
-
-func TestCacheControl_PerEndpoint(t *testing.T) {
-	cfg := config.KromgoConfig{
-		Defaults: config.Defaults{CacheSeconds: 60}, // global default
-		Badges: []config.Badge{
-			{ID: "fast", Query: "q"},
-			{ID: "slow", Query: "q", CacheSeconds: new(3600)},
+// TestServeBadge_Expressions covers value/color CEL evaluation, including the
+// no-data and runtime-error paths, each with its own config.
+func TestServeBadge_Expressions(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name     string
+		badge    config.Badge
+		sample   []promtest.Sample
+		matrix   []float64
+		path     string
+		wantCode int
+		contains []string
+	}{
+		{
+			name:     "humanize duration value",
+			badge:    config.Badge{ID: "uptime", Query: "q", Value: "humanizeDuration(result)"},
+			sample:   promtest.Scalar("9000", map[string]string{"job": "node"}),
+			path:     "/badges/uptime?format=json",
+			wantCode: http.StatusOK,
+			contains: []string{`"value":"2h30m"`},
+		},
+		{
+			name:     "value from label",
+			badge:    config.Badge{ID: "ver", Query: "q", Value: `labels["version"]`},
+			sample:   promtest.Scalar("0", map[string]string{"version": "v1.2.3"}),
+			path:     "/badges/ver?format=shields",
+			wantCode: http.StatusOK,
+			contains: []string{`"message":"v1.2.3"`},
+		},
+		{
+			// Indexing a missing label is a CEL runtime error → 500.
+			name:     "missing label is runtime error",
+			badge:    config.Badge{ID: "ver", Query: "q", Value: `labels["version"]`},
+			sample:   promtest.Scalar("0", map[string]string{"other": "x"}),
+			path:     "/badges/ver",
+			wantCode: http.StatusInternalServerError,
+			contains: []string{`"isError":true`},
+		},
+		{
+			name: "state expressions",
+			badge: config.Badge{
+				ID:    "ceph",
+				Query: "q",
+				Value: `result == 0.0 ? "Healthy" : "Critical"`,
+				Color: `result == 0.0 ? "green" : "red"`,
+			},
+			sample:   promtest.Scalar("0", map[string]string{"job": "node"}),
+			path:     "/badges/ceph?format=shields",
+			wantCode: http.StatusOK,
+			contains: []string{`"message":"Healthy"`, `"color":"green"`},
+		},
+		{
+			name:     "empty vector renders no data",
+			badge:    baseConfig().Badges[0],
+			sample:   nil, // empty instant vector
+			path:     "/badges/cpu?format=shields",
+			wantCode: http.StatusOK,
+			contains: []string{`"message":"no data"`},
+		},
+		{
+			// type: range reduces a range query to one value (avg of 10,20,30 = 20).
+			name: "range type reduces to one value",
+			badge: config.Badge{
+				ID:    "cpu_avg",
+				Type:  config.TypeRange,
+				Query: "q",
+				Value: `string(result) + "%"`,
+				Range: &config.RangeQuery{Last: "1h", Reduce: config.ReduceAvg},
+			},
+			matrix:   []float64{10, 20, 30},
+			path:     "/badges/cpu_avg?format=shields",
+			wantCode: http.StatusOK,
+			contains: []string{`"message":"20%"`},
 		},
 	}
-	srv := mockProm(t, "1", nil)
-	h := newHandlerForTest(t, cfg, srv.URL)
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			srv := promtest.Server(t, tc.sample, tc.matrix)
+			h := newHandlerForTest(t, config.KromgoConfig{Badges: []config.Badge{tc.badge}}, srv.URL)
 
-	t.Run("global default", func(t *testing.T) {
-		w := promtest.Get(t, h.Mux(), "/badges/fast?format=shields")
-		assert.Equal(t, "public, max-age=60", w.Header().Get("Cache-Control"))
-		assert.Contains(t, w.Body.String(), `"cacheSeconds":60`)
-	})
+			w := promtest.Get(t, h.Mux(), tc.path)
 
-	t.Run("per-endpoint override", func(t *testing.T) {
-		w := promtest.Get(t, h.Mux(), "/badges/slow?format=shields")
-		assert.Equal(t, "public, max-age=3600", w.Header().Get("Cache-Control"))
-		assert.Contains(t, w.Body.String(), `"cacheSeconds":3600`)
-	})
-}
-
-func TestCacheControl_DisabledByDefault(t *testing.T) {
-	srv := mockProm(t, "17.5", nil)
-	h := newHandlerForTest(t, baseConfig(), srv.URL) // no CacheSeconds
-
-	w := promtest.Get(t, h.Mux(), "/badges/cpu")
-
-	assert.Empty(t, w.Header().Get("Cache-Control"))
-}
-
-func TestCacheControl_ErrorsNotCached(t *testing.T) {
-	cfg := config.KromgoConfig{
-		Defaults: config.Defaults{CacheSeconds: 60},
-		Graphs:   []config.Graph{{ID: "cpu", Query: "q", MaxDuration: "24h"}},
+			assert.Equal(t, tc.wantCode, w.Code)
+			for _, want := range tc.contains {
+				assert.Contains(t, w.Body.String(), want)
+			}
+		})
 	}
-	srv := mockProm(t, "1", nil)
-	h := newHandlerForTest(t, cfg, srv.URL)
-
-	// Window exceeds maxDuration → 400; the cache header must be no-store, not max-age.
-	w := promtest.Get(t, h.Mux(), "/graphs/cpu?format=json&last=7d")
-
-	assert.Equal(t, http.StatusBadRequest, w.Code)
-	assert.Equal(t, "no-store", w.Header().Get("Cache-Control"))
 }
 
-func TestServeGraph_JSON(t *testing.T) {
-	srv := mockProm(t, "0", []float64{1, 2, 3})
-	h := newHandlerForTest(t, baseConfig(), srv.URL)
+func TestCacheControl(t *testing.T) {
+	t.Parallel()
 
-	w := promtest.Get(t, h.Mux(), "/graphs/cpu?format=json&last=1h")
+	t.Run("per-endpoint override and global default", func(t *testing.T) {
+		t.Parallel()
+		cfg := config.KromgoConfig{
+			Defaults: config.Defaults{CacheSeconds: 60}, // global default
+			Badges: []config.Badge{
+				{ID: "fast", Query: "q"},
+				{ID: "slow", Query: "q", CacheSeconds: new(3600)},
+			},
+		}
+		srv := mockProm(t, "1", nil)
+		h := newHandlerForTest(t, cfg, srv.URL)
 
-	assert.Equal(t, http.StatusOK, w.Code)
-	assert.Equal(t, "application/json", w.Header().Get("Content-Type"))
-	var resp HistoryResponse
-	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
-	assert.Equal(t, "cpu", resp.ID)
-	require.Len(t, resp.Series, 1)
-	assert.Len(t, resp.Series[0].Data, 3)
+		cases := []struct {
+			name, id, wantCache, wantBody string
+		}{
+			{"global default", "fast", "public, max-age=60", `"cacheSeconds":60`},
+			{"per-endpoint override", "slow", "public, max-age=3600", `"cacheSeconds":3600`},
+		}
+		for _, tc := range cases {
+			t.Run(tc.name, func(t *testing.T) {
+				t.Parallel()
+				w := promtest.Get(t, h.Mux(), "/badges/"+tc.id+"?format=shields")
+				assert.Equal(t, tc.wantCache, w.Header().Get("Cache-Control"))
+				assert.Contains(t, w.Body.String(), tc.wantBody)
+			})
+		}
+	})
+
+	t.Run("disabled by default", func(t *testing.T) {
+		t.Parallel()
+		srv := mockProm(t, "17.5", nil)
+		h := newHandlerForTest(t, baseConfig(), srv.URL) // no CacheSeconds
+		w := promtest.Get(t, h.Mux(), "/badges/cpu")
+		assert.Empty(t, w.Header().Get("Cache-Control"))
+	})
+
+	t.Run("errors not cached", func(t *testing.T) {
+		t.Parallel()
+		cfg := config.KromgoConfig{
+			Defaults: config.Defaults{CacheSeconds: 60},
+			Graphs:   []config.Graph{{ID: "cpu", Query: "q", MaxDuration: "24h"}},
+		}
+		srv := mockProm(t, "1", nil)
+		h := newHandlerForTest(t, cfg, srv.URL)
+
+		// Window exceeds maxDuration → 400; the cache header must be no-store, not max-age.
+		w := promtest.Get(t, h.Mux(), "/graphs/cpu?format=json&last=7d")
+
+		assert.Equal(t, http.StatusBadRequest, w.Code)
+		assert.Equal(t, "no-store", w.Header().Get("Cache-Control"))
+	})
 }
 
-func TestServeGraph_SVGDefault(t *testing.T) {
-	srv := mockProm(t, "0", []float64{10, 20, 15, 30})
-	h := newHandlerForTest(t, baseConfig(), srv.URL)
-
-	w := promtest.Get(t, h.Mux(), "/graphs/cpu?last=1h")
-
-	assert.Equal(t, http.StatusOK, w.Code)
-	assert.Equal(t, "image/svg+xml", w.Header().Get("Content-Type"))
-	assert.True(t, strings.HasPrefix(w.Body.String(), "<svg"))
-}
-
-func TestServeGraph_PNG(t *testing.T) {
-	srv := mockProm(t, "0", []float64{10, 20, 15, 30})
-	h := newHandlerForTest(t, baseConfig(), srv.URL)
-
-	w := promtest.Get(t, h.Mux(), "/graphs/cpu?format=png&last=1h")
-
-	assert.Equal(t, http.StatusOK, w.Code)
-	assert.Equal(t, "image/png", w.Header().Get("Content-Type"))
-	assert.Equal(t, []byte{0x89, 'P', 'N', 'G'}, w.Body.Bytes()[:4])
-}
-
-func TestServeGraph_Theme(t *testing.T) {
-	srv := mockProm(t, "0", []float64{10, 20, 15, 30})
-	h := newHandlerForTest(t, baseConfig(), srv.URL)
-
-	w := promtest.Get(t, h.Mux(), "/graphs/cpu?theme=dracula&last=1h")
-
-	assert.Equal(t, http.StatusOK, w.Code)
-	assert.Contains(t, w.Body.String(), "rgb(40,42,54)") // dracula background
-}
-
-func TestServeGraph_WindowTooLarge(t *testing.T) {
-	srv := mockProm(t, "0", []float64{1, 2})
-	h := newHandlerForTest(t, baseConfig(), srv.URL) // graph MaxDuration 24h
-
-	w := promtest.Get(t, h.Mux(), "/graphs/cpu?format=json&last=7d")
-
-	assert.Equal(t, http.StatusBadRequest, w.Code)
-}
-
-func TestServeGraph_NotFound(t *testing.T) {
-	srv := mockProm(t, "0", nil)
-	h := newHandlerForTest(t, baseConfig(), srv.URL)
-
-	w := promtest.Get(t, h.Mux(), "/graphs/nope")
-
-	assert.Equal(t, http.StatusNotFound, w.Code)
+// TestServeGraph_Output covers the graph output formats; each case supplies its own
+// range matrix and request.
+func TestServeGraph_Output(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name   string
+		matrix []float64
+		path   string
+		check  func(t *testing.T, w *httptest.ResponseRecorder)
+	}{
+		{"json", []float64{1, 2, 3}, "/graphs/cpu?format=json&last=1h", func(t *testing.T, w *httptest.ResponseRecorder) {
+			assert.Equal(t, http.StatusOK, w.Code)
+			assert.Equal(t, "application/json", w.Header().Get("Content-Type"))
+			var resp HistoryResponse
+			require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+			assert.Equal(t, "cpu", resp.ID)
+			require.Len(t, resp.Series, 1)
+			assert.Len(t, resp.Series[0].Data, 3)
+		}},
+		{"svg default", []float64{10, 20, 15, 30}, "/graphs/cpu?last=1h", assertSVGOK},
+		{"png", []float64{10, 20, 15, 30}, "/graphs/cpu?format=png&last=1h", func(t *testing.T, w *httptest.ResponseRecorder) {
+			assert.Equal(t, http.StatusOK, w.Code)
+			assert.Equal(t, "image/png", w.Header().Get("Content-Type"))
+			assert.Equal(t, []byte{0x89, 'P', 'N', 'G'}, w.Body.Bytes()[:4])
+		}},
+		{"theme", []float64{10, 20, 15, 30}, "/graphs/cpu?theme=dracula&last=1h", func(t *testing.T, w *httptest.ResponseRecorder) {
+			assert.Equal(t, http.StatusOK, w.Code)
+			assert.Contains(t, w.Body.String(), "rgb(40,42,54)") // dracula background
+		}},
+		{"window too large", []float64{1, 2}, "/graphs/cpu?format=json&last=7d", func(t *testing.T, w *httptest.ResponseRecorder) {
+			assert.Equal(t, http.StatusBadRequest, w.Code)
+		}},
+		{"not found", nil, "/graphs/nope", func(t *testing.T, w *httptest.ResponseRecorder) {
+			assert.Equal(t, http.StatusNotFound, w.Code)
+		}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			srv := mockProm(t, "0", tc.matrix)
+			h := newHandlerForTest(t, baseConfig(), srv.URL)
+			tc.check(t, promtest.Get(t, h.Mux(), tc.path))
+		})
+	}
 }
 
 func TestIndexRoute(t *testing.T) {
+	t.Parallel()
 	cfg := baseConfig() // endpoints are shown in the gallery by default
 	srv := mockProm(t, "0", nil)
 	h := newHandlerForTest(t, cfg, srv.URL)
@@ -377,6 +376,7 @@ func TestIndexRoute(t *testing.T) {
 }
 
 func TestAssetsRoute(t *testing.T) {
+	t.Parallel()
 	srv := mockProm(t, "0", nil)
 	h := newHandlerForTest(t, baseConfig(), srv.URL)
 

--- a/internal/kromgo/index_test.go
+++ b/internal/kromgo/index_test.go
@@ -13,6 +13,7 @@ import (
 // --- hidden ---
 
 func TestHidden(t *testing.T) {
+	t.Parallel()
 	cases := []struct {
 		name string
 		item *bool
@@ -27,6 +28,7 @@ func TestHidden(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 			assert.Equal(t, tc.want, hidden(tc.item, tc.def))
 		})
 	}
@@ -35,6 +37,7 @@ func TestHidden(t *testing.T) {
 // --- baseURL ---
 
 func TestBaseURL(t *testing.T) {
+	t.Parallel()
 	req := func(host, xfp string, withTLS bool) *http.Request {
 		r := httptest.NewRequest(http.MethodGet, "/", nil)
 		r.Host = host
@@ -62,6 +65,7 @@ func TestBaseURL(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 			assert.Equal(t, tc.want, baseURL(tc.r))
 		})
 	}
@@ -70,6 +74,7 @@ func TestBaseURL(t *testing.T) {
 // --- markdownItem / mdEscapeAlt ---
 
 func TestMarkdownItem(t *testing.T) {
+	t.Parallel()
 	assert.Equal(t, "![CPU](http://example.com/badges/cpu)",
 		markdownItem("http://example.com", "badges", "cpu", "CPU").Markdown)
 	// Relative URL when the host is unusable.
@@ -92,6 +97,7 @@ func getIndex(h *Handler) *httptest.ResponseRecorder {
 }
 
 func TestIndexHandler_GalleryHeadersAndAssets(t *testing.T) {
+	t.Parallel()
 	h := newTestHandler(config.KromgoConfig{
 		Badges: []config.Badge{{ID: "cpu", Title: "CPU"}},
 	})
@@ -116,6 +122,7 @@ func TestIndexHandler_GalleryHeadersAndAssets(t *testing.T) {
 }
 
 func TestIndexHandler_BadgesAndGraphs_SnippetsPresent(t *testing.T) {
+	t.Parallel()
 	h := newTestHandler(config.KromgoConfig{
 		Badges: []config.Badge{{ID: "cpu", Title: "CPU"}},
 		Graphs: []config.Graph{{ID: "cpu"}}, // no title → falls back to id
@@ -131,6 +138,7 @@ func TestIndexHandler_BadgesAndGraphs_SnippetsPresent(t *testing.T) {
 }
 
 func TestIndexHandler_AllHidden_ShowsEmptyState(t *testing.T) {
+	t.Parallel()
 	// Hide all badges via the per-type default.
 	h := newTestHandler(config.KromgoConfig{
 		Badges:   []config.Badge{{ID: "cpu"}, {ID: "mem"}},
@@ -144,6 +152,7 @@ func TestIndexHandler_AllHidden_ShowsEmptyState(t *testing.T) {
 }
 
 func TestIndexHandler_MixedVisibility(t *testing.T) {
+	t.Parallel()
 	// Badges hidden by default; cpu opts back in with gallery.hidden: false.
 	h := newTestHandler(config.KromgoConfig{
 		Badges: []config.Badge{
@@ -159,6 +168,7 @@ func TestIndexHandler_MixedVisibility(t *testing.T) {
 }
 
 func TestIndexHandler_PerEndpointHidden(t *testing.T) {
+	t.Parallel()
 	// Default is shown; a per-endpoint gallery.hidden: true hides just that one.
 	h := newTestHandler(config.KromgoConfig{
 		Badges: []config.Badge{
@@ -173,12 +183,14 @@ func TestIndexHandler_PerEndpointHidden(t *testing.T) {
 }
 
 func TestIndexHandler_NoEndpoints_ShowsEmptyState(t *testing.T) {
+	t.Parallel()
 	h := newTestHandler(config.KromgoConfig{})
 	body := getIndex(h).Body.String()
 	assert.Contains(t, body, "No endpoints to show")
 }
 
 func TestIndexHandler_GalleryDisabled_ShowsLanding(t *testing.T) {
+	t.Parallel()
 	h := newTestHandler(config.KromgoConfig{
 		Badges:  []config.Badge{{ID: "cpu", Title: "CPU"}},
 		Gallery: config.Gallery{Enabled: new(false)},
@@ -197,6 +209,7 @@ func TestIndexHandler_GalleryDisabled_ShowsLanding(t *testing.T) {
 // --- assets handler ---
 
 func TestAssetsHandler(t *testing.T) {
+	t.Parallel()
 	get := func(path string) *httptest.ResponseRecorder {
 		req := httptest.NewRequest(http.MethodGet, path, nil)
 		w := httptest.NewRecorder()

--- a/internal/kromgo/instant.go
+++ b/internal/kromgo/instant.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/home-operations/kromgo/internal/logging"
 	v1 "github.com/prometheus/client_golang/api/prometheus/v1"
 	"github.com/prometheus/common/model"
 )
@@ -37,7 +38,7 @@ func (h *Handler) serveBadge(w http.ResponseWriter, r *http.Request) {
 
 	metricLabel := "unknown"
 	defer func() { requestsTotal.WithLabelValues("badge", metricLabel, format).Inc() }()
-	log := requestLogger(r, "badge", id, format)
+	log := logging.FromContext(r.Context()).With("kind", "badge", "id", id, "format", format)
 
 	badge, ok := h.badges[id]
 	if !ok {

--- a/internal/kromgo/reduce_test.go
+++ b/internal/kromgo/reduce_test.go
@@ -19,6 +19,7 @@ func samples(values ...float64) []model.SamplePair {
 }
 
 func TestReduceSamples(t *testing.T) {
+	t.Parallel()
 	vals := samples(10, 30, 20, 40)
 	cases := map[string]float64{
 		config.ReduceFirst: 10,
@@ -30,6 +31,7 @@ func TestReduceSamples(t *testing.T) {
 	}
 	for op, want := range cases {
 		t.Run(op, func(t *testing.T) {
+			t.Parallel()
 			got, _, ok := reduceSamples(vals, op)
 			require.True(t, ok)
 			assert.Equal(t, want, float64(got))
@@ -38,6 +40,7 @@ func TestReduceSamples(t *testing.T) {
 }
 
 func TestReduceSamples_SkipsNonFinite(t *testing.T) {
+	t.Parallel()
 	vals := samples(10, math.NaN(), 30, math.Inf(1))
 	got, _, ok := reduceSamples(vals, config.ReduceAvg)
 	require.True(t, ok)
@@ -45,11 +48,13 @@ func TestReduceSamples_SkipsNonFinite(t *testing.T) {
 }
 
 func TestReduceSamples_AllNonFinite(t *testing.T) {
+	t.Parallel()
 	_, _, ok := reduceSamples(samples(math.NaN(), math.Inf(-1)), config.ReduceLast)
 	assert.False(t, ok)
 }
 
 func TestReduceMatrix_DropsEmptySeries(t *testing.T) {
+	t.Parallel()
 	matrix := model.Matrix{
 		&model.SampleStream{Metric: model.Metric{"a": "1"}, Values: samples(1, 2, 3)},
 		&model.SampleStream{Metric: model.Metric{"b": "2"}, Values: samples(math.NaN())},

--- a/internal/kromgo/response.go
+++ b/internal/kromgo/response.go
@@ -2,6 +2,7 @@ package kromgo
 
 import (
 	"encoding/json"
+	"fmt"
 	"log/slog"
 	"net/http"
 )
@@ -38,6 +39,14 @@ func writeJSON(w http.ResponseWriter, v any) error {
 func writeSVG(w http.ResponseWriter, svg []byte) {
 	w.Header().Set("Content-Type", mimeSVG)
 	_, _ = w.Write(svg)
+}
+
+// setCache applies a successful response's cache policy; writeError later overrides
+// it with no-store on failures.
+func setCache(w http.ResponseWriter, cacheSeconds int) {
+	if cacheSeconds > 0 {
+		w.Header().Set("Cache-Control", fmt.Sprintf("public, max-age=%d", cacheSeconds))
+	}
 }
 
 // writeJSONOr writes v as JSON, falling back to a 500 error response on marshal failure.

--- a/internal/kromgo/security_test.go
+++ b/internal/kromgo/security_test.go
@@ -14,6 +14,7 @@ const xssPayload = `</text><script>alert(1)</script>`
 // Badge text comes from a CEL value or a metric label; it must never reach the SVG
 // unescaped, or opening the badge as a top-level document would execute script.
 func TestSecurity_BadgeEscapesSVG(t *testing.T) {
+	t.Parallel()
 	r, err := newBadgeRenderer(config.BadgeDefaults{})
 	require.NoError(t, err)
 
@@ -26,6 +27,7 @@ func TestSecurity_BadgeEscapesSVG(t *testing.T) {
 
 // Graph legend labels come from metric label values and must be escaped too.
 func TestSecurity_GraphLegendEscapesSVG(t *testing.T) {
+	t.Parallel()
 	matrix := model.Matrix{&model.SampleStream{
 		Metric: model.Metric{"instance": model.LabelValue(xssPayload)},
 		Values: []model.SamplePair{{Timestamp: 0, Value: 1}, {Timestamp: 60000, Value: 2}},

--- a/internal/logging/logging.go
+++ b/internal/logging/logging.go
@@ -1,0 +1,55 @@
+// Package logging centralizes kromgo's slog setup and carries a request-scoped
+// logger through context so middleware and handlers share one set of base fields.
+package logging
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"os"
+	"strings"
+)
+
+// Init configures the default slog logger from LOG_LEVEL (debug/info/warn/error,
+// default info) and LOG_FORMAT (text or json, default json).
+func Init() {
+	slog.SetDefault(slog.New(newHandler(os.Stdout, os.Getenv("LOG_LEVEL"), os.Getenv("LOG_FORMAT"))))
+}
+
+// newHandler builds a JSON (default) or text slog handler at the given level.
+func newHandler(w io.Writer, level, format string) slog.Handler {
+	opts := &slog.HandlerOptions{Level: parseLevel(level)}
+	if strings.EqualFold(format, "text") {
+		return slog.NewTextHandler(w, opts)
+	}
+	return slog.NewJSONHandler(w, opts)
+}
+
+func parseLevel(s string) slog.Level {
+	switch strings.ToLower(s) {
+	case "debug":
+		return slog.LevelDebug
+	case "warn":
+		return slog.LevelWarn
+	case "error":
+		return slog.LevelError
+	default:
+		return slog.LevelInfo
+	}
+}
+
+type ctxKey struct{}
+
+// WithLogger returns a copy of ctx carrying l, retrievable via FromContext.
+func WithLogger(ctx context.Context, l *slog.Logger) context.Context {
+	return context.WithValue(ctx, ctxKey{}, l)
+}
+
+// FromContext returns the logger stored in ctx, or slog.Default() if none is set
+// (e.g. handlers exercised in tests without the server middleware).
+func FromContext(ctx context.Context) *slog.Logger {
+	if l, ok := ctx.Value(ctxKey{}).(*slog.Logger); ok {
+		return l
+	}
+	return slog.Default()
+}

--- a/internal/logging/logging_test.go
+++ b/internal/logging/logging_test.go
@@ -1,0 +1,89 @@
+package logging
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"log/slog"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseLevel(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		in   string
+		want slog.Level
+	}{
+		{"debug", slog.LevelDebug},
+		{"DEBUG", slog.LevelDebug},
+		{"warn", slog.LevelWarn},
+		{"error", slog.LevelError},
+		{"info", slog.LevelInfo},
+		{"", slog.LevelInfo},
+		{"nonsense", slog.LevelInfo},
+	}
+	for _, tc := range cases {
+		t.Run(tc.in, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tc.want, parseLevel(tc.in))
+		})
+	}
+}
+
+func TestNewHandler(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name        string
+		format      string
+		wantJSON    bool
+		debugLogged bool
+		level       string
+	}{
+		{name: "json default", format: "", wantJSON: true, level: "info", debugLogged: false},
+		{name: "text", format: "text", wantJSON: false, level: "info", debugLogged: false},
+		{name: "debug level emits debug", format: "json", wantJSON: true, level: "debug", debugLogged: true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			var buf bytes.Buffer
+			log := slog.New(newHandler(&buf, tc.level, tc.format))
+			log.Debug("dbg")
+			log.Info("nfo", "k", "v")
+
+			out := buf.String()
+			if tc.wantJSON {
+				assert.Contains(t, out, `"msg":"nfo"`)
+				var rec map[string]any
+				require.NoError(t, json.Unmarshal([]byte(firstLine(out)), &rec))
+			} else {
+				assert.Contains(t, out, "msg=nfo")
+			}
+			assert.Equal(t, tc.debugLogged, bytes.Contains([]byte(out), []byte("dbg")))
+		})
+	}
+}
+
+func TestFromContext_Fallback(t *testing.T) {
+	t.Parallel()
+	assert.Same(t, slog.Default(), FromContext(context.Background()))
+}
+
+func TestWithLogger_RoundTrip(t *testing.T) {
+	t.Parallel()
+	want := slog.New(newHandler(&bytes.Buffer{}, "info", "json"))
+	ctx := WithLogger(context.Background(), want)
+	assert.Same(t, want, FromContext(ctx))
+}
+
+func firstLine(s string) string {
+	for i, r := range s {
+		if r == '\n' {
+			return s[:i]
+		}
+	}
+	return s
+}

--- a/internal/prometheus/client_test.go
+++ b/internal/prometheus/client_test.go
@@ -15,17 +15,20 @@ import (
 )
 
 func TestNew_EmptyAddress(t *testing.T) {
+	t.Parallel()
 	_, err := New("", 0)
 	assert.Error(t, err)
 }
 
 func TestNew_Valid(t *testing.T) {
+	t.Parallel()
 	c, err := New("http://localhost:9090", 0)
 	require.NoError(t, err)
 	assert.NotNil(t, c)
 }
 
 func TestQuery_Vector(t *testing.T) {
+	t.Parallel()
 	srv := promtest.Server(t, promtest.Scalar("17.5", map[string]string{"job": "node"}), nil)
 	c, err := New(srv.URL, 0)
 	require.NoError(t, err)
@@ -40,6 +43,7 @@ func TestQuery_Vector(t *testing.T) {
 }
 
 func TestQueryRange_Matrix(t *testing.T) {
+	t.Parallel()
 	srv := promtest.Server(t, nil, []float64{1, 2, 3})
 	c, err := New(srv.URL, 0)
 	require.NoError(t, err)
@@ -55,6 +59,7 @@ func TestQueryRange_Matrix(t *testing.T) {
 }
 
 func TestQuery_ServerError(t *testing.T) {
+	t.Parallel()
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		http.Error(w, "boom", http.StatusInternalServerError)
 	}))
@@ -68,6 +73,7 @@ func TestQuery_ServerError(t *testing.T) {
 }
 
 func TestQuery_TimeoutApplied(t *testing.T) {
+	t.Parallel()
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		time.Sleep(200 * time.Millisecond)
 		w.WriteHeader(http.StatusOK)

--- a/internal/server/middleware.go
+++ b/internal/server/middleware.go
@@ -3,21 +3,39 @@ package server
 import (
 	"log/slog"
 	"net/http"
+	"strconv"
+	"sync/atomic"
 	"time"
 
 	"github.com/home-operations/kromgo/internal/config"
+	"github.com/home-operations/kromgo/internal/logging"
 )
 
-// withMiddleware wraps h with recovery, security headers, and optional access
-// logging. Middleware is applied outermost-first: recover → access log → security
-// headers → handler. Rate limiting is intentionally left to a reverse proxy (see
-// the README).
+// withMiddleware wraps h with request-logger injection, recovery, optional access
+// logging, and security headers. Middleware is applied outermost-first: inject logger
+// → recover → access log → security headers → handler. Rate limiting is intentionally
+// left to a reverse proxy (see the README).
 func withMiddleware(h http.Handler, sc config.ServerConfig) http.Handler {
 	h = secureHeaders(h)
 	if sc.ServerLogging {
 		h = accessLog(h)
 	}
-	return recoverer(h)
+	return injectLogger(recoverer(h))
+}
+
+var requestCounter atomic.Uint64
+
+// injectLogger attaches a request-scoped logger (request_id, method, path) to the
+// request context so downstream middleware and handlers share one set of base fields.
+func injectLogger(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		log := slog.With(
+			slog.String("request_id", strconv.FormatUint(requestCounter.Add(1), 36)),
+			slog.String("method", r.Method),
+			slog.String("path", r.URL.Path),
+		)
+		next.ServeHTTP(w, r.WithContext(logging.WithLogger(r.Context(), log)))
+	})
 }
 
 // secureHeaders sets defensive response headers. nosniff stops MIME confusion; the
@@ -49,9 +67,7 @@ func accessLog(next http.Handler) http.Handler {
 		rec := &statusRecorder{ResponseWriter: w, status: http.StatusOK}
 		start := time.Now()
 		next.ServeHTTP(rec, r)
-		slog.LogAttrs(r.Context(), slog.LevelInfo, "request",
-			slog.String("method", r.Method),
-			slog.String("path", r.URL.Path),
+		logging.FromContext(r.Context()).LogAttrs(r.Context(), slog.LevelInfo, "request",
 			slog.Int("status", rec.status),
 			slog.Duration("duration", time.Since(start)),
 		)
@@ -62,9 +78,8 @@ func recoverer(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		defer func() {
 			if rec := recover(); rec != nil {
-				slog.LogAttrs(r.Context(), slog.LevelError, "panic recovered",
+				logging.FromContext(r.Context()).LogAttrs(r.Context(), slog.LevelError, "panic recovered",
 					slog.Any("panic", rec),
-					slog.String("path", r.URL.Path),
 				)
 				w.WriteHeader(http.StatusInternalServerError)
 			}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -37,7 +37,7 @@ func Run(ctx context.Context, sc config.ServerConfig, app http.Handler) error {
 	}
 	health := &http.Server{
 		Addr:              net.JoinHostPort(sc.HealthHost, strconv.Itoa(sc.HealthPort)),
-		Handler:           recoverer(secureHeaders(healthMux())),
+		Handler:           injectLogger(recoverer(secureHeaders(healthMux()))),
 		ReadHeaderTimeout: readHeaderTimeout,
 		ReadTimeout:       sc.ServerReadTimeout,
 		WriteTimeout:      sc.ServerWriteTimeout,

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -3,18 +3,19 @@ package server
 import (
 	"context"
 	"fmt"
-	"net"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 	"time"
 
 	"github.com/home-operations/kromgo/internal/config"
+	"github.com/home-operations/kromgo/internal/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 func TestSecureHeaders(t *testing.T) {
+	t.Parallel()
 	h := secureHeaders(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	}))
@@ -28,9 +29,11 @@ func TestSecureHeaders(t *testing.T) {
 }
 
 func TestHealthMux(t *testing.T) {
+	t.Parallel()
 	mux := healthMux()
 	for _, path := range []string{"/healthz", "/-/health", "/readyz", "/-/ready", "/metrics"} {
 		t.Run(path, func(t *testing.T) {
+			t.Parallel()
 			req := httptest.NewRequest(http.MethodGet, path, nil)
 			w := httptest.NewRecorder()
 			mux.ServeHTTP(w, req)
@@ -40,6 +43,7 @@ func TestHealthMux(t *testing.T) {
 }
 
 func TestRecoverer_TurnsPanicInto500(t *testing.T) {
+	t.Parallel()
 	h := recoverer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
 		panic("boom")
 	}))
@@ -49,6 +53,7 @@ func TestRecoverer_TurnsPanicInto500(t *testing.T) {
 }
 
 func TestAccessLog_PassesThrough(t *testing.T) {
+	t.Parallel()
 	h := accessLog(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusTeapot)
 		_, _ = w.Write([]byte("hi"))
@@ -60,6 +65,7 @@ func TestAccessLog_PassesThrough(t *testing.T) {
 }
 
 func TestWithMiddleware_LoggingOptional(t *testing.T) {
+	t.Parallel()
 	called := false
 	base := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		called = true
@@ -77,9 +83,10 @@ func TestWithMiddleware_LoggingOptional(t *testing.T) {
 }
 
 func TestRun_GracefulShutdown(t *testing.T) {
+	t.Parallel()
 	sc := config.ServerConfig{
-		ServerHost: "127.0.0.1", ServerPort: freePort(t),
-		HealthHost: "127.0.0.1", HealthPort: freePort(t),
+		ServerHost: "127.0.0.1", ServerPort: testutil.FreePort(t),
+		HealthHost: "127.0.0.1", HealthPort: testutil.FreePort(t),
 	}
 	app := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
@@ -107,12 +114,4 @@ func TestRun_GracefulShutdown(t *testing.T) {
 	case <-time.After(3 * time.Second):
 		t.Fatal("Run did not return after context cancellation")
 	}
-}
-
-func freePort(t *testing.T) int {
-	t.Helper()
-	l, err := net.Listen("tcp", "127.0.0.1:0")
-	require.NoError(t, err)
-	defer func() { _ = l.Close() }()
-	return l.Addr().(*net.TCPAddr).Port
 }

--- a/internal/testutil/testutil.go
+++ b/internal/testutil/testutil.go
@@ -1,0 +1,41 @@
+// Package testutil holds small cross-package test helpers. Like promtest it is a
+// normal package (not a _test.go file) so build-tagged tests can import it, but it
+// is referenced only from test code and never linked into the kromgo binary.
+package testutil
+
+import (
+	"net"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// FreePort returns a TCP port that was free at call time. It binds :0, reads the
+// assigned port, then releases it — so the port is available for a server to bind,
+// at the usual (small) risk of a race before that bind happens.
+func FreePort(t *testing.T) int {
+	t.Helper()
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	defer func() { _ = l.Close() }()
+	return l.Addr().(*net.TCPAddr).Port
+}
+
+// ModuleRoot walks up from the test's working directory to the directory holding go.mod.
+func ModuleRoot(t *testing.T) string {
+	t.Helper()
+	dir, err := os.Getwd()
+	require.NoError(t, err)
+	for {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			return dir
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			t.Fatal("could not locate go.mod")
+		}
+		dir = parent
+	}
+}

--- a/test/e2e/harness.go
+++ b/test/e2e/harness.go
@@ -6,7 +6,6 @@ package e2e
 import (
 	"context"
 	"fmt"
-	"net"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -16,6 +15,7 @@ import (
 	"time"
 
 	"github.com/home-operations/kromgo/internal/promtest"
+	"github.com/home-operations/kromgo/internal/testutil"
 	"github.com/stretchr/testify/require"
 )
 
@@ -48,7 +48,7 @@ type harness struct {
 func start(t *testing.T) *harness {
 	t.Helper()
 
-	root := moduleRoot(t)
+	root := testutil.ModuleRoot(t)
 	bin := filepath.Join(t.TempDir(), "kromgo")
 	build := exec.Command("go", "build", "-o", bin, "./cmd/kromgo")
 	build.Dir = root
@@ -61,8 +61,8 @@ func start(t *testing.T) *harness {
 	configPath := filepath.Join(t.TempDir(), "config.yaml")
 	require.NoError(t, os.WriteFile(configPath, []byte(configYAML), 0o600))
 
-	serverPort := freePort(t)
-	healthPort := freePort(t)
+	serverPort := testutil.FreePort(t)
+	healthPort := testutil.FreePort(t)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	cmd := exec.CommandContext(ctx, bin, "-config", configPath)
@@ -114,29 +114,4 @@ func (h *harness) get(path string) *http.Response {
 	resp, err := http.Get(h.baseURL + path)
 	require.NoError(h.t, err)
 	return resp
-}
-
-func freePort(t *testing.T) int {
-	t.Helper()
-	l, err := net.Listen("tcp", "127.0.0.1:0")
-	require.NoError(t, err)
-	defer func() { _ = l.Close() }()
-	return l.Addr().(*net.TCPAddr).Port
-}
-
-// moduleRoot walks up from this file's directory to the directory containing go.mod.
-func moduleRoot(t *testing.T) string {
-	t.Helper()
-	dir, err := os.Getwd()
-	require.NoError(t, err)
-	for {
-		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
-			return dir
-		}
-		parent := filepath.Dir(dir)
-		if parent == dir {
-			t.Fatal("could not locate go.mod")
-		}
-		dir = parent
-	}
 }

--- a/test/integration/gallery_test.go
+++ b/test/integration/gallery_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/home-operations/kromgo/internal/kromgo"
 	"github.com/home-operations/kromgo/internal/prometheus"
 	"github.com/home-operations/kromgo/internal/promtest"
+	"github.com/home-operations/kromgo/internal/testutil"
 	"github.com/stretchr/testify/require"
 	"go.yaml.in/yaml/v4"
 )
@@ -152,7 +153,7 @@ hljs.highlightAll();
 
 	out := os.Getenv("GALLERY_OUT")
 	if out == "" {
-		out = filepath.Join(moduleRoot(t), "kromgo-gallery.html")
+		out = filepath.Join(testutil.ModuleRoot(t), "kromgo-gallery.html")
 	}
 	require.NoError(t, os.WriteFile(out, []byte(b.String()), 0o644))
 	t.Logf("gallery written: open %q", out)
@@ -246,19 +247,4 @@ func idFromPath(path string) string {
 		p = p[:i]
 	}
 	return p
-}
-
-// moduleRoot walks up from the test's working directory to the directory holding go.mod.
-func moduleRoot(t *testing.T) string {
-	t.Helper()
-	dir, err := os.Getwd()
-	require.NoError(t, err)
-	for {
-		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
-			return dir
-		}
-		parent := filepath.Dir(dir)
-		require.NotEqual(t, parent, dir, "could not locate go.mod")
-		dir = parent
-	}
 }


### PR DESCRIPTION
## Summary

A behavior-preserving cleanliness refactor. The production code was already clean and modern (all-`slog`, `cmp.Or`/generics/`slices`/`sync.OnceValue`/Go 1.22 routing), so the substantive work is a logging architecture improvement plus comprehensive test cleanup, with a few cohesion moves.

### Logging — request-scoped logger via context
- New `internal/logging` package owns `slog` setup (`Init`, moved out of `main.go`) and carries a request-scoped logger through `context` (`WithLogger`/`FromContext`).
- New `injectLogger` middleware stamps `request_id`/`method`/`path` once; `accessLog`, `recoverer`, and the badge/graph handlers all derive from it.
- Removes the field duplication that existed between the access log and the per-handler logger, and correlates every line of a request by `request_id`:
  ```
  level=ERROR msg="badge not found"  request_id=1 method=GET path=/badges/nope kind=badge id=nope format=svg
  level=INFO  msg="request"          request_id=1 method=GET path=/badges/nope status=404 duration=…
  ```

### Cohesion moves (behavior identical)
- Rename `timeseries.go` → `graph_query.go` (name now reflects the graph pipeline).
- Move `setCache` into `response.go` alongside the other response writers.
- Replace the `graphParamError` struct with `errors.New` sentinels.

### Tests
- Table-drive `formatting_test.go` and the badge/graph output cases in `handler_test.go`.
- Extract the duplicated `freePort`/`moduleRoot` helpers (3 copies) into a new `internal/testutil` package.
- Run the suite in parallel. The global-counter test stays serial by design (its before/after delta is measured before the parallel batch runs); the two `t.Setenv` config tests stay non-parallel (parallel + `t.Setenv` panics).

No config surface change — `config.schema.json` is unchanged.

## Test plan
- [x] `mise run lint` → 0 issues
- [x] `go test -race -count=2 ./...` → pass (no parallel flakiness)
- [x] `mise run test` → pass (config 93%, kromgo 90%, logging 93%, prometheus 88%, server 94%)
- [x] `mise run test-e2e` → pass
- [x] schema unchanged (`git diff --quiet config.schema.json`)
- [x] manual run: access-log and handler error lines share `request_id` in both JSON and text formats

🤖 Generated with [Claude Code](https://claude.com/claude-code)