### PR TITLE
feat: support Simple Icons for badge icons alongside MDI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,4 @@ node_modules/
 internal/kromgo/assets/marked.js
 internal/kromgo/assets/github-markdown.css
 internal/kromgo/assets/mdi.txt.gz
+internal/kromgo/assets/si.txt.gz

--- a/.mise.toml
+++ b/.mise.toml
@@ -11,12 +11,13 @@ zizmor = "1.25.2"
 # no-op until package-lock.json (or the generator) changes — e.g. a Renovate bump —
 # so the depends below stay cheap.
 [tasks.assets]
-description = "Vendor npm deps and build embedded assets (marked.js, github-markdown.css, full MDI set)"
+description = "Vendor npm deps and build embedded assets (marked.js, github-markdown.css, full MDI and Simple Icons sets)"
 sources = ["package.json", "package-lock.json", "cmd/genassets/main.go"]
 outputs = [
   "internal/kromgo/assets/marked.js",
   "internal/kromgo/assets/github-markdown.css",
   "internal/kromgo/assets/mdi.txt.gz",
+  "internal/kromgo/assets/si.txt.gz",
 ]
 run = "npm ci && go run ./cmd/genassets"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
-# Vendor the npm packages (marked, github-markdown-css, @mdi/svg) that become the
-# embedded assets. Pinned by package-lock.json and kept current by Renovate.
+# Vendor the npm packages (marked, github-markdown-css, @mdi/svg, simple-icons) that
+# become the embedded assets. Pinned by package-lock.json and kept current by Renovate.
 FROM node:24-alpine AS assets
 WORKDIR /src
 COPY package.json package-lock.json ./

--- a/README.md
+++ b/README.md
@@ -126,16 +126,20 @@ Each entry under `badges:` defines an instant-value endpoint at `/badges/{id}`.
 | `value`        | no       | CEL expression for the displayed string — see [Value and color](#value-and-color)    |
 | `color`        | no       | CEL expression for the color — see [Value and color](#value-and-color)               |
 | `style`        | no       | `flat` (default), `flat-square`, or `plastic`                                        |
-| `icon`         | no       | A Material Design Icon on the SVG badge, e.g. `mdi:server-outline` — see below       |
+| `icon`         | no       | An icon on the SVG badge, e.g. `mdi:server-outline` or `si:kubernetes` — see below   |
 | `gallery`      | no       | Per-badge gallery settings, e.g. `gallery: {hidden: true}` — see [Gallery](#gallery) |
 | `cacheSeconds` | no       | Override `defaults.cacheSeconds` for this badge                                      |
 
 #### Icons
 
-`icon` renders a [Material Design Icon](https://pictogrammers.com/library/mdi/) on the left of the SVG
-badge, written as `mdi:<name>` (e.g. `mdi:server-outline`). It is **SVG-only** — the `shields` and
-`json` formats have no icon field and ignore it. The icon sits left of the `title`; with an icon and
-no `title`, the badge shows just the icon and the value (the `id` fallback is suppressed).
+`icon` renders an icon on the left of the SVG badge, written as `<set>:<name>` for one of two sets:
+
+- **`mdi:<name>`** — a [Material Design Icon](https://pictogrammers.com/library/mdi/), e.g. `mdi:server-outline`.
+- **`si:<slug>`** — a [Simple Icons](https://simpleicons.org/) brand logo, e.g. `si:kubernetes`.
+
+It is **SVG-only** — the `shields` and `json` formats have no icon field and ignore it. The icon is
+drawn in white and sits left of the `title`; with an icon and no `title`, the badge shows just the
+icon and the value (the `id` fallback is suppressed).
 
 ```yaml
 badges:
@@ -143,14 +147,19 @@ badges:
       query: count(kube_node_info)
       icon: mdi:server-outline
       title: Nodes
+    - id: version
+      query: kubernetes_build_info
+      icon: si:kubernetes
+      title: Kubernetes
 ```
 
-The **entire** Material Design Icons set (~7,400 glyphs) is embedded in the binary — no network or
-disk access at runtime — so any `mdi:<name>` from [the library](https://pictogrammers.com/library/mdi/)
-works (e.g. `mdi:kubernetes`, `mdi:database-outline`, `mdi:rocket-launch`). The set is stored
-compressed (~0.8 MB) and decoded into memory on first use. An unknown name fails fast at startup. The
-icon data is built from the `@mdi/svg` npm package **at build time** (not committed) — see
-[Building from source](#building-from-source).
+Both **entire** sets are embedded in the binary — no network or disk access at runtime — so any
+`mdi:<name>` from [the MDI library](https://pictogrammers.com/library/mdi/) (~7,400 glyphs, e.g.
+`mdi:database-outline`, `mdi:rocket-launch`) or any `si:<slug>` from [Simple Icons](https://simpleicons.org/)
+(~3,400 logos, e.g. `si:docker`, `si:grafana`, `si:prometheus`) works. The sets are stored compressed
+(~0.8 MB MDI, ~1.9 MB Simple Icons) and each is decoded into memory only on first use. An unknown set
+or name fails fast at startup. The icon data is built from the `@mdi/svg` and `simple-icons` npm
+packages **at build time** (not committed) — see [Building from source](#building-from-source).
 
 #### Range badges
 
@@ -571,11 +580,11 @@ summary.
 
 ## Building from source
 
-The gallery's `marked.js` / `github-markdown.css` and the full Material Design Icons set are vendored
-via npm (`package.json` + `package-lock.json`) and baked into the binary with `//go:embed` rather than
-committed. [`cmd/genassets`](cmd/genassets/main.go) reads `node_modules` and writes the embedded files,
-so a build runs `npm ci` once (network) and the resulting binary is self-contained (nothing fetched at
-runtime).
+The gallery's `marked.js` / `github-markdown.css` and the full Material Design Icons and Simple Icons
+sets are vendored via npm (`package.json` + `package-lock.json`) and baked into the binary with
+`//go:embed` rather than committed. [`cmd/genassets`](cmd/genassets/main.go) reads `node_modules` and
+writes the embedded files, so a build runs `npm ci` once (network) and the resulting binary is
+self-contained (nothing fetched at runtime).
 
 ```bash
 mise run assets   # npm ci + go run ./cmd/genassets (re-runs only when the lockfile changes)
@@ -584,7 +593,7 @@ go build ./cmd/kromgo
 
 `mise run test` / `lint` / `test-e2e` depend on `assets`, so they build it automatically; CI and the
 Docker build (a dedicated `node` stage) do the same. [Renovate](https://docs.renovatebot.com) keeps
-`marked`, `github-markdown-css`, and `@mdi/svg` current via PRs against `package.json`.
+`marked`, `github-markdown-css`, `@mdi/svg`, and `simple-icons` current via PRs against `package.json`.
 
 ## Upgrading 0.11 → 0.12
 

--- a/cmd/genassets/main.go
+++ b/cmd/genassets/main.go
@@ -1,8 +1,8 @@
 // Command genassets builds the assets that internal/kromgo embeds with //go:embed,
 // from the npm packages vendored in node_modules (marked, github-markdown-css,
-// @mdi/svg). Versions are pinned in package.json / package-lock.json and kept
-// current by Renovate; this program is a pure local transform — it does no network
-// I/O. Run `npm ci` (or `mise run assets`) first to populate node_modules.
+// @mdi/svg, simple-icons). Versions are pinned in package.json / package-lock.json
+// and kept current by Renovate; this program is a pure local transform — it does no
+// network I/O. Run `npm ci` (or `mise run assets`) first to populate node_modules.
 //
 //	npm ci && go run ./cmd/genassets
 //
@@ -31,8 +31,9 @@ var (
 	// sourceMapRe drops a trailing //# sourceMappingURL comment so the embedded JS
 	// references nothing external.
 	sourceMapRe = regexp.MustCompile(`(?m)^\s*//[#@]\s*sourceMappingURL=.*$\n?`)
-	// mdiPathRe extracts the geometry from an MDI glyph's single <path d="…">.
-	mdiPathRe = regexp.MustCompile(`\bd="([^"]+)"`)
+	// svgPathRe extracts the geometry from an icon glyph's single <path d="…">. The
+	// word boundary skips id="…" so it matches only the path's d attribute.
+	svgPathRe = regexp.MustCompile(`\bd="([^"]+)"`)
 )
 
 func main() {
@@ -53,6 +54,7 @@ func run() error {
 		{"marked.js", genMarked},
 		{"github-markdown.css", genMarkdownCSS},
 		{"mdi.txt.gz", genMDI},
+		{"si.txt.gz", genSimpleIcons},
 	}
 	for _, s := range steps {
 		data, err := s.gen()
@@ -80,9 +82,21 @@ func genMarkdownCSS() ([]byte, error) {
 	return os.ReadFile(filepath.Join(nodeModules, "github-markdown-css", "github-markdown.css"))
 }
 
-// genMDI reads every @mdi/svg glyph and builds a gzipped, sorted "name\tpath" table.
+// genMDI builds the Material Design Icons table from @mdi/svg.
 func genMDI() ([]byte, error) {
-	dir := filepath.Join(nodeModules, "@mdi", "svg", "svg")
+	return genIconSet("MDI", filepath.Join(nodeModules, "@mdi", "svg", "svg"))
+}
+
+// genSimpleIcons builds the Simple Icons table from simple-icons. Each file is named
+// by slug and holds a single 24x24 <path> alongside a <title>, like @mdi/svg.
+func genSimpleIcons() ([]byte, error) {
+	return genIconSet("Simple Icons", filepath.Join(nodeModules, "simple-icons", "icons"))
+}
+
+// genIconSet reads every single-path SVG glyph under dir (filename minus ".svg" is the
+// icon name) and builds a gzipped, sorted "name\tpath" table. label is used only in the
+// progress line.
+func genIconSet(label, dir string) ([]byte, error) {
 	entries, err := os.ReadDir(dir)
 	if err != nil {
 		return nil, err
@@ -97,7 +111,7 @@ func genMDI() ([]byte, error) {
 		if err != nil {
 			return nil, err
 		}
-		m := mdiPathRe.FindSubmatch(data)
+		m := svgPathRe.FindSubmatch(data)
 		if m == nil {
 			return nil, fmt.Errorf("no path in %s", e.Name())
 		}
@@ -127,6 +141,6 @@ func genMDI() ([]byte, error) {
 	if err := zw.Close(); err != nil {
 		return nil, err
 	}
-	fmt.Printf("      (%d MDI icons)\n", len(names))
+	fmt.Printf("      (%d %s icons)\n", len(names), label)
 	return buf.Bytes(), nil
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -97,7 +97,8 @@ type Badge struct {
 	Color string `yaml:"color,omitempty" json:"color,omitempty"`
 	// Style overrides defaults.badge.style for this badge.
 	Style string `yaml:"style,omitempty" json:"style,omitempty"`
-	// Icon renders a Material Design Icon on the SVG badge, e.g. "mdi:server-outline".
+	// Icon renders an icon on the SVG badge, written as "<set>:<name>": a Material Design
+	// Icon (e.g. "mdi:server-outline") or a Simple Icons brand logo (e.g. "si:kubernetes").
 	Icon string `yaml:"icon,omitempty" json:"icon,omitempty"`
 	// Gallery holds this badge's gallery settings (e.g. hidden), overriding defaults.badge.gallery.
 	Gallery GallerySettings `yaml:"gallery,omitempty" json:"gallery,omitempty"`

--- a/internal/kromgo/badge.go
+++ b/internal/kromgo/badge.go
@@ -233,17 +233,28 @@ func colorNameToHex(color string) string {
 	return colorGreen
 }
 
-// resolveIcon parses an "mdi:<name>" reference into 24x24 SVG path data. Empty
-// input returns "". An unknown name or non-mdi prefix errors (fails fast at startup).
+// iconSets maps an icon-set prefix to its lazily-decoded name→path table.
+var iconSets = map[string]func() map[string]string{
+	"mdi": mdiIcons, // Material Design Icons (https://pictogrammers.com/library/mdi/)
+	"si":  siIcons,  // Simple Icons brand set (https://simpleicons.org/)
+}
+
+// resolveIcon parses a "<set>:<name>" reference (e.g. "mdi:server-outline" or
+// "si:kubernetes") into 24x24 SVG path data. Empty input returns "". An unknown set
+// or name errors (fails fast at startup).
 func resolveIcon(ref string) (string, error) {
 	if ref == "" {
 		return "", nil
 	}
-	name, ok := strings.CutPrefix(ref, "mdi:")
+	prefix, name, ok := strings.Cut(ref, ":")
 	if !ok {
-		return "", fmt.Errorf("icon %q: only mdi: icons are supported (e.g. mdi:server-outline)", ref)
+		return "", fmt.Errorf("icon %q: expected \"<set>:<name>\" (e.g. mdi:server-outline or si:kubernetes)", ref)
 	}
-	path, ok := mdiIcons()[name]
+	set, ok := iconSets[prefix]
+	if !ok {
+		return "", fmt.Errorf("icon %q: unknown icon set %q (supported: mdi, si)", ref, prefix)
+	}
+	path, ok := set()[name]
 	if !ok {
 		return "", fmt.Errorf("unknown icon %q", ref)
 	}

--- a/internal/kromgo/badge_test.go
+++ b/internal/kromgo/badge_test.go
@@ -78,6 +78,11 @@ func TestResolveIcon(t *testing.T) {
 	require.NoError(t, err)
 	assert.True(t, strings.HasPrefix(rocket, "M"))
 
+	// Simple Icons brand logos resolve from the si: set.
+	si, err := resolveIcon("si:kubernetes")
+	require.NoError(t, err)
+	assert.True(t, strings.HasPrefix(si, "M"))
+
 	empty, err := resolveIcon("")
 	require.NoError(t, err)
 	assert.Empty(t, empty)
@@ -85,12 +90,19 @@ func TestResolveIcon(t *testing.T) {
 	_, err = resolveIcon("mdi:does-not-exist")
 	assert.Error(t, err)
 
-	_, err = resolveIcon("server-outline") // missing mdi: prefix
+	_, err = resolveIcon("si:does-not-exist")
+	assert.Error(t, err)
+
+	_, err = resolveIcon("nope:server-outline") // unknown icon set
+	assert.Error(t, err)
+
+	_, err = resolveIcon("server-outline") // missing set prefix
 	assert.Error(t, err)
 }
 
-func TestMDIIconsEmbedded(t *testing.T) {
+func TestIconSetsEmbedded(t *testing.T) {
 	t.Parallel()
-	// The full Material Design Icons set is embedded and decodes cleanly.
+	// Both full sets are embedded and decode cleanly.
 	assert.Greater(t, len(mdiIcons()), 7000, "full MDI set should be embedded")
+	assert.Greater(t, len(siIcons()), 3000, "full Simple Icons set should be embedded")
 }

--- a/internal/kromgo/icons.go
+++ b/internal/kromgo/icons.go
@@ -11,17 +11,27 @@ import (
 
 // mdiData is the full Material Design Icons set (https://pictogrammers.com/library/mdi/,
 // Apache-2.0): a gzipped, tab-separated "name\tpath" table, one 24x24 glyph path per
-// line. It is built from the @mdi/svg npm package by cmd/genassets (not committed) and
-// embedded; see the README's "Building from source".
+// line. siData is the same for the Simple Icons brand set (https://simpleicons.org/,
+// CC0-1.0). Both are built from npm packages (@mdi/svg, simple-icons) by cmd/genassets
+// (not committed) and embedded; see the README's "Building from source".
 //
 //go:embed assets/mdi.txt.gz
 var mdiData []byte
 
-// mdiIcons lazily decodes mdiData into a name→path map on first use, so configs
-// without icons never pay the decode cost. The set is read-only after build.
-var mdiIcons = sync.OnceValue(func() map[string]string {
+//go:embed assets/si.txt.gz
+var siData []byte
+
+// mdiIcons / siIcons lazily decode their table into a name→path map on first use, so
+// configs that don't use a set never pay its decode cost. The sets are read-only after build.
+var (
+	mdiIcons = sync.OnceValue(func() map[string]string { return decodeIcons(mdiData) })
+	siIcons  = sync.OnceValue(func() map[string]string { return decodeIcons(siData) })
+)
+
+// decodeIcons parses a gzipped, tab-separated "name\tpath" table into a name→path map.
+func decodeIcons(data []byte) map[string]string {
 	icons := map[string]string{}
-	zr, err := gzip.NewReader(bytes.NewReader(mdiData))
+	zr, err := gzip.NewReader(bytes.NewReader(data))
 	if err != nil {
 		return icons // embedded data is generated; a failure here just means "unknown icon"
 	}
@@ -35,4 +45,4 @@ var mdiIcons = sync.OnceValue(func() map[string]string {
 		}
 	}
 	return icons
-})
+}

--- a/internal/kromgo/index_test.go
+++ b/internal/kromgo/index_test.go
@@ -228,6 +228,7 @@ func TestAssetsHandler(t *testing.T) {
 	assert.Contains(t, js.Header().Get("Content-Type"), "javascript")
 
 	assert.Equal(t, http.StatusNotFound, get("/assets/mdi.txt.gz").Code, "icon data is embedded but not web-served")
+	assert.Equal(t, http.StatusNotFound, get("/assets/si.txt.gz").Code, "icon data is embedded but not web-served")
 	assert.Equal(t, http.StatusNotFound, get("/assets/nope.txt").Code)
 	// No directory listing, and a traversal attempt cannot escape the embedded FS.
 	assert.Equal(t, http.StatusNotFound, get("/assets/").Code, "no directory listing")

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,8 @@
       "dependencies": {
         "@mdi/svg": "7.4.47",
         "github-markdown-css": "5.9.0",
-        "marked": "18.0.4"
+        "marked": "18.0.4",
+        "simple-icons": "16.22.0"
       }
     },
     "node_modules/@mdi/svg": {
@@ -42,6 +43,25 @@
       },
       "engines": {
         "node": ">= 20"
+      }
+    },
+    "node_modules/simple-icons": {
+      "version": "16.22.0",
+      "resolved": "https://registry.npmjs.org/simple-icons/-/simple-icons-16.22.0.tgz",
+      "integrity": "sha512-/raPcEWh89R2O2IMmHum6W2dF99NNX3yWikVXKUalkDIWz3Rw/S2S+oDPTgJcIGsRh+25m0y8vj4aBaV/KPz3Q==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/simple-icons"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/simple-icons"
+        }
+      ],
+      "license": "CC0-1.0",
+      "engines": {
+        "node": ">=0.12.18"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -2,11 +2,12 @@
   "name": "kromgo-assets",
   "version": "0.0.0",
   "private": true,
-  "description": "Build-time assets embedded into the kromgo binary by cmd/genassets. Not published; managed here so Renovate keeps marked, github-markdown-css, and the Material Design Icons set up to date.",
+  "description": "Build-time assets embedded into the kromgo binary by cmd/genassets. Not published; managed here so Renovate keeps marked, github-markdown-css, and the Material Design Icons and Simple Icons sets up to date.",
   "license": "Apache-2.0",
   "dependencies": {
     "@mdi/svg": "7.4.47",
     "github-markdown-css": "5.9.0",
-    "marked": "18.0.4"
+    "marked": "18.0.4",
+    "simple-icons": "16.22.0"
   }
 }

--- a/test/integration/gallery_test.go
+++ b/test/integration/gallery_test.go
@@ -68,7 +68,7 @@ func TestGallery(t *testing.T) {
 		{ID: "pods", Title: "Pods", Query: "vector(1204)", Value: "humanizeNumber(result)", Icon: "mdi:kubernetes"},
 		{ID: "uptime", Title: "Uptime", Query: "vector(40348800)", Value: "humanizeDuration(result)", Icon: "mdi:clock-outline"},
 		{ID: "age", Title: "Age", Query: "vector(5961600)", Value: "humanizeDays(result)", Icon: "mdi:server-outline"},
-		{ID: "ver", Title: "Kubernetes", Query: `label_replace(vector(1), "v", "1.36.1", "", "")`, Value: `labels["v"]`, Color: `"blue"`, Icon: "mdi:kubernetes"},
+		{ID: "ver", Title: "Kubernetes", Query: `label_replace(vector(1), "v", "1.36.1", "", "")`, Value: `labels["v"]`, Color: `"blue"`, Icon: "si:kubernetes"},
 		{ID: "ok", Query: "vector(1)", Value: `"online"`, Color: `"green"`, Icon: "mdi:check-circle-outline"},
 	}
 	byID := map[string]config.Badge{}


### PR DESCRIPTION
## Summary

- Badges can now reference [Simple Icons](https://simpleicons.org/) brand logos as `icon: si:<slug>` (e.g. `si:kubernetes`, `si:docker`, `si:grafana`), in addition to the existing `icon: mdi:<name>`.
- The icon pipeline is generalized into a small **set registry**: a `<set>:<name>` reference splits on the first `:` and dispatches to the right embedded table (`mdi` or `si`), erroring clearly at startup on an unknown set or name. The renderer was already set-agnostic, so icons render **white**, exactly like MDI.
- Simple Icons are built and embedded the same way as MDI — a gzipped `name\tpath` table generated from the `simple-icons` npm package by `cmd/genassets` at build time (not committed), decoded lazily on first use. `genMDI` was refactored into a reusable `genIconSet` helper.

## Details

- `cmd/genassets/main.go`: `genIconSet(label, dir)` helper + new `si.txt.gz` step reading `node_modules/simple-icons/icons`; `mdiPathRe` → `svgPathRe`.
- `internal/kromgo/icons.go`: shared `decodeIcons` helper; new `//go:embed assets/si.txt.gz` set with a lazy `siIcons` loader.
- `internal/kromgo/badge.go`: `iconSets` registry + generalized `resolveIcon`.
- `package.json`: add `simple-icons@16.22.0` (CC0-1.0); lockfile updated. `.gitignore`, `.mise.toml`, `Dockerfile` updated for the new generated asset.
- Docs: README Icons + Building-from-source sections, and the `Badge.Icon` struct comment.

Note: the Simple Icons set adds ~1.9 MB compressed to the binary (vs ~0.8 MB for MDI), since brand-logo paths are more detailed.

## Test plan

- [x] `go run ./cmd/genassets` builds both tables (7,447 MDI / 3,438 Simple Icons)
- [x] `go test ./...` passes (incl. new `si:` resolution, two-set embedded check, `/assets/si.txt.gz` 404)
- [x] Self-contained e2e suite passes; integration package compiles (`gallery_test` now renders `si:kubernetes`)
- [x] Manual: ran the binary against a mock Prometheus — `si:kubernetes` and `mdi:server-outline` both render a white `<path fill="#fff">` icon (si path matches the embedded `kubernetes.svg`); unknown `si:<name>` and unknown set `fa:` fail fast at startup with clear errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)