### PR TITLE
feat: stamp build version into the container image

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -19,6 +19,9 @@ jobs:
       packages: write
     uses: docker/github-builder/.github/workflows/build.yml@17bd7d64200cae4ba58ffc099934e8012ae320f2 # v1.10.0
     with:
+      build-args: |
+        VERSION=${{ github.ref_name }}
+        REVISION=${{ github.sha }}
       meta-images: ghcr.io/${{ github.repository }}
       meta-tags: |
         type=semver,pattern={{version}}

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,8 @@ COPY package.json package-lock.json ./
 RUN npm ci --no-audit --no-fund
 
 FROM golang:1.26-alpine AS builder
+ARG VERSION=dev
+ARG REVISION=dev
 WORKDIR /src
 RUN apk add --no-cache upx ca-certificates
 COPY go.mod go.sum ./
@@ -15,7 +17,7 @@ COPY . .
 # neither node_modules nor the generated assets are committed to the repo.
 COPY --from=assets /src/node_modules ./node_modules
 RUN go run ./cmd/genassets
-RUN CGO_ENABLED=0 go build -ldflags "-s -w" -trimpath -o /out/kromgo ./cmd/kromgo
+RUN CGO_ENABLED=0 go build -ldflags "-s -w -X main.Version=${VERSION} -X main.Gitsha=${REVISION}" -trimpath -o /out/kromgo ./cmd/kromgo
 RUN upx --best --lzma /out/kromgo
 
 FROM scratch


### PR DESCRIPTION
Part of standardizing build-version stamping across the org's Go services (`external-dns-unifi-webhook` is the reference).

kromgo already declares `main.Version`/`main.Gitsha` (logged at startup), but the Dockerfile never stamped them, so released images reported `version=local`. This wires them up:

- **Dockerfile**: add `ARG VERSION`/`ARG REVISION`, inject via `-ldflags "-X main.Version=${VERSION} -X main.Gitsha=${REVISION}"`.
- **release.yaml**: pass `VERSION=${{ github.ref_name }}` (tag on release, `main` on main pushes) and `REVISION=${{ github.sha }}` to the reusable `docker/github-builder` workflow.

No Go changes.

> The `Release` workflow calls a reusable workflow, so it can't run on this PR — the stamping is first exercised on the next push to `main` / release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
