### PR TITLE
feat: embed DejaVu Sans + Comic Neue via npm (DejaVu default, shields.io look)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,7 @@ internal/kromgo/assets/marked.js
 internal/kromgo/assets/github-markdown.css
 internal/kromgo/assets/mdi.txt.gz
 internal/kromgo/assets/si.txt.gz
+internal/kromgo/assets/dejavu-sans.ttf
+internal/kromgo/assets/dejavu-sans-bold.ttf
+internal/kromgo/assets/comic-neue.ttf
+internal/kromgo/assets/comic-neue-bold.ttf

--- a/.mise.toml
+++ b/.mise.toml
@@ -11,13 +11,17 @@ zizmor = "1.25.2"
 # no-op until package-lock.json (or the generator) changes — e.g. a Renovate bump —
 # so the depends below stay cheap.
 [tasks.assets]
-description = "Vendor npm deps and build embedded assets (marked.js, github-markdown.css, full MDI and Simple Icons sets)"
+description = "Vendor npm deps and build embedded assets (marked.js, github-markdown.css, MDI + Simple Icons sets, DejaVu Sans + Comic Neue fonts)"
 sources = ["package.json", "package-lock.json", "cmd/genassets/main.go"]
 outputs = [
   "internal/kromgo/assets/marked.js",
   "internal/kromgo/assets/github-markdown.css",
   "internal/kromgo/assets/mdi.txt.gz",
   "internal/kromgo/assets/si.txt.gz",
+  "internal/kromgo/assets/dejavu-sans.ttf",
+  "internal/kromgo/assets/dejavu-sans-bold.ttf",
+  "internal/kromgo/assets/comic-neue.ttf",
+  "internal/kromgo/assets/comic-neue-bold.ttf",
 ]
 run = "npm ci && go run ./cmd/genassets"
 

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ same-named field. All keys are optional.
 defaults:
     cacheSeconds: 0 # Cache-Control max-age in seconds; 0 disables caching
     badge:
-        font: go-regular # go-regular (default), go-bold, go-medium, go-mono
+        font: dejavu-sans # dejavu-sans (default, shields.io-style), dejavu-sans-bold, comic-neue, comic-neue-bold
         size: 11 # badge font size in points
         style: flat # flat (default), flat-square, or plastic
         gallery:
@@ -105,7 +105,7 @@ defaults:
         height: 200 # image height in px
         legend: true # show the series legend
         theme: light # color theme — see Themes below
-        font: roboto # text font — see Themes below
+        font: dejavu-sans # text font — see Themes below
         gallery:
             hidden: false # list graphs in the gallery (default); true hides them
 ```
@@ -312,10 +312,17 @@ kromgo's bundled palettes (an unknown value falls back to the default):
   (via the official [catppuccin/go](https://github.com/catppuccin/go) palette), `dracula`, `monokai`,
   `night-owl`.
 
-`font` accepts a built-in name: `roboto` (default), `notosans`, `notosans-bold`, or the embedded Go
-family `go-regular` / `go-bold` / `go-medium` / `go-mono`. (Badges use the Go family; `defaults.badge.font`
-defaults to `go-regular`.) Fonts are compiled into the binary — there's no reading from disk, so add a
-new face by PRing it into the registry. An unknown name fails fast at startup.
+`font` accepts one of:
+
+- **`dejavu-sans`** (the default) / **`dejavu-sans-bold`** — the free, metric-compatible stand-in for the
+  Verdana that [shields.io](https://shields.io) renders with. Vendored via npm (`dejavu-fonts-ttf`).
+- **`comic-neue`** / **`comic-neue-bold`** — a free Comic Sans alternative (Google Fonts, via
+  `@expo-google-fonts/comic-neue`), for when a badge wants some personality.
+
+Both faces are compiled in by `cmd/genassets` (kept current by Renovate). Badges and graphs default to
+`dejavu-sans` (shields.io-style — 11 px text, 20 px tall); set `font:` to opt into the others. Fonts are
+compiled into the binary — there's no reading from disk, so add a face by vendoring it (npm) and PRing it
+into the registry. An unknown name fails fast at startup.
 
 ## Gallery
 

--- a/cmd/genassets/main.go
+++ b/cmd/genassets/main.go
@@ -1,6 +1,7 @@
 // Command genassets builds the assets that internal/kromgo embeds with //go:embed,
 // from the npm packages vendored in node_modules (marked, github-markdown-css,
-// @mdi/svg, simple-icons). Versions are pinned in package.json / package-lock.json
+// @mdi/svg, simple-icons, and the DejaVu Sans + Comic Neue TrueType faces). Versions are
+// pinned in package.json / package-lock.json
 // and kept current by Renovate; this program is a pure local transform — it does no
 // network I/O. Run `npm ci` (or `mise run assets`) first to populate node_modules.
 //
@@ -55,6 +56,10 @@ func run() error {
 		{"github-markdown.css", genMarkdownCSS},
 		{"mdi.txt.gz", genMDI},
 		{"si.txt.gz", genSimpleIcons},
+		{"dejavu-sans.ttf", genFont("dejavu-fonts-ttf/ttf/DejaVuSans.ttf")},
+		{"dejavu-sans-bold.ttf", genFont("dejavu-fonts-ttf/ttf/DejaVuSans-Bold.ttf")},
+		{"comic-neue.ttf", genFont("@expo-google-fonts/comic-neue/400Regular/ComicNeue_400Regular.ttf")},
+		{"comic-neue-bold.ttf", genFont("@expo-google-fonts/comic-neue/700Bold/ComicNeue_700Bold.ttf")},
 	}
 	for _, s := range steps {
 		data, err := s.gen()
@@ -80,6 +85,15 @@ func genMarked() ([]byte, error) {
 
 func genMarkdownCSS() ([]byte, error) {
 	return os.ReadFile(filepath.Join(nodeModules, "github-markdown-css", "github-markdown.css"))
+}
+
+// genFont copies a TrueType font verbatim from node_modules. The vendored font packages
+// (dejavu-fonts-ttf, @expo-google-fonts/*) ship the static .ttf files the badge (sfnt) and
+// graph (freetype) renderers parse; @fontsource ships only woff2, which neither can read.
+func genFont(rel string) func() ([]byte, error) {
+	return func() ([]byte, error) {
+		return os.ReadFile(filepath.Join(nodeModules, filepath.FromSlash(rel)))
+	}
 }
 
 // genMDI builds the Material Design Icons table from @mdi/svg.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -50,7 +50,8 @@ type Defaults struct {
 
 // BadgeDefaults holds the default SVG badge rendering settings.
 type BadgeDefaults struct {
-	// Font selects the badge font by name (go-regular, go-bold, go-medium, go-mono); empty = go-regular.
+	// Font selects the badge font: dejavu-sans (default, shields.io-style), dejavu-sans-bold,
+	// comic-neue, or comic-neue-bold.
 	Font string `yaml:"font,omitempty" json:"font,omitempty"`
 	// Size is the font size in points (defaults to 11).
 	Size int `yaml:"size,omitempty" json:"size,omitempty"`
@@ -72,7 +73,7 @@ type GraphDefaults struct {
 	Legend *bool `yaml:"legend,omitempty" json:"legend,omitempty"`
 	// Theme selects the color theme (e.g. "dark", "grafana", "catppuccin-mocha", "dracula").
 	Theme string `yaml:"theme,omitempty" json:"theme,omitempty"`
-	// Font selects the text font by name (roboto, notosans, notosans-bold, go-regular, go-bold, …).
+	// Font selects the text font: dejavu-sans (default), dejavu-sans-bold, comic-neue, or comic-neue-bold.
 	Font string `yaml:"font,omitempty" json:"font,omitempty"`
 	// Gallery is the default gallery visibility for graphs.
 	Gallery GallerySettings `yaml:"gallery,omitempty" json:"gallery,omitempty"`

--- a/internal/kromgo/badge_test.go
+++ b/internal/kromgo/badge_test.go
@@ -49,7 +49,7 @@ func TestNewBadgeRenderer_UnknownFont(t *testing.T) {
 
 func TestNewBadgeRenderer_NamedFont(t *testing.T) {
 	t.Parallel()
-	r, err := newBadgeRenderer(config.BadgeDefaults{Font: "go-bold"})
+	r, err := newBadgeRenderer(config.BadgeDefaults{Font: "dejavu-sans-bold"})
 	require.NoError(t, err)
 	require.NotNil(t, r)
 }

--- a/internal/kromgo/chart.go
+++ b/internal/kromgo/chart.go
@@ -136,8 +136,8 @@ func renderChart(matrix model.Matrix, p chartParams) ([]byte, error) {
 		opt.Legend.Show = &hide
 	}
 
-	// Font is set on the painter (the non-deprecated default-font hook); nil leaves
-	// the chart library's default.
+	// Font is set on the painter (the non-deprecated default-font hook). resolveGraphFont
+	// always returns a face (DejaVu Sans by default), so p.font is never nil here.
 	painter := charts.NewPainter(charts.PainterOptions{
 		OutputFormat: p.format, // "svg" or "png"
 		Width:        p.width,

--- a/internal/kromgo/chart_test.go
+++ b/internal/kromgo/chart_test.go
@@ -114,16 +114,12 @@ func TestChartParams_WithOverrides(t *testing.T) {
 
 func TestResolveGraphFont(t *testing.T) {
 	t.Parallel()
-	for _, name := range []string{"", "roboto", "notosans", "go-regular", "go-bold", "go-medium", "go-mono"} {
+	for _, name := range []string{"", "dejavu-sans", "dejavu-sans-bold"} {
 		t.Run("ok/"+name, func(t *testing.T) {
 			t.Parallel()
 			f, err := resolveGraphFont(name)
 			require.NoError(t, err)
-			if name == "" {
-				assert.Nil(t, f, "empty name uses the library default")
-			} else {
-				assert.NotNil(t, f)
-			}
+			assert.NotNil(t, f, "empty name defaults to DejaVu Sans")
 		})
 	}
 	// An unknown font name errors (no disk fallback).
@@ -136,7 +132,7 @@ func TestResolveGraphFont(t *testing.T) {
 
 func TestRenderChart_CustomFont(t *testing.T) {
 	t.Parallel()
-	font, err := resolveGraphFont("go-bold")
+	font, err := resolveGraphFont("dejavu-sans-bold")
 	require.NoError(t, err)
 	svg, err := renderChart(makeMatrix([][]float64{{1, 2, 3}}),
 		chartParams{width: 400, height: 150, font: font, format: formatSVG})

--- a/internal/kromgo/fonts.go
+++ b/internal/kromgo/fonts.go
@@ -1,40 +1,42 @@
 package kromgo
 
 import (
+	_ "embed"
 	"fmt"
 
-	charts "github.com/go-analyze/charts"
 	"github.com/golang/freetype/truetype"
-	"golang.org/x/image/font/gofont/gobold"
-	"golang.org/x/image/font/gofont/gomedium"
-	"golang.org/x/image/font/gofont/gomono"
-	"golang.org/x/image/font/gofont/goregular"
 )
 
 // Fonts are compiled into the binary, never read from disk — the image is scratch
-// and we control the set. Add a face by importing it here and PRing it into the
-// registry. embeddedFonts are the Go family from golang.org/x/image; graphs can
-// also use the chart library's bundled fonts (builtinGraphFonts).
+// and we control the set. DejaVu Sans is the default for badges and graphs (the free,
+// metric-compatible stand-in for the Verdana shields.io renders with); Comic Neue is a
+// second selectable face. Both are vendored via npm and generated into assets/ by
+// cmd/genassets (regular + bold). Add a face by vendoring it (npm) and PRing it here.
+
+//go:embed assets/dejavu-sans.ttf
+var dejavuSansTTF []byte
+
+//go:embed assets/dejavu-sans-bold.ttf
+var dejavuSansBoldTTF []byte
+
+//go:embed assets/comic-neue.ttf
+var comicNeueTTF []byte
+
+//go:embed assets/comic-neue-bold.ttf
+var comicNeueBoldTTF []byte
 
 var embeddedFonts = map[string][]byte{
-	"go-regular": goregular.TTF,
-	"go-bold":    gobold.TTF,
-	"go-medium":  gomedium.TTF,
-	"go-mono":    gomono.TTF,
-}
-
-// builtinGraphFonts are the chart library's bundled fonts, selectable by name.
-var builtinGraphFonts = map[string]bool{
-	charts.FontFamilyRoboto:       true,
-	charts.FontFamilyNotoSans:     true,
-	charts.FontFamilyNotoSansBold: true,
+	"dejavu-sans":      dejavuSansTTF,
+	"dejavu-sans-bold": dejavuSansBoldTTF,
+	"comic-neue":       comicNeueTTF,
+	"comic-neue-bold":  comicNeueBoldTTF,
 }
 
 // resolveBadgeFont returns the TTF bytes for a badge font name (empty = the default
-// Go regular face). The badge renderer parses these bytes with sfnt to draw glyph paths.
+// DejaVu Sans face). The badge renderer parses these bytes with sfnt to draw glyph paths.
 func resolveBadgeFont(name string) ([]byte, error) {
 	if name == "" {
-		return goregular.TTF, nil
+		return dejavuSansTTF, nil
 	}
 	if data := embeddedFonts[name]; data != nil {
 		return data, nil
@@ -42,21 +44,14 @@ func resolveBadgeFont(name string) ([]byte, error) {
 	return nil, fmt.Errorf("unknown font %q", name)
 }
 
-// resolveGraphFont returns the parsed font for a graph font name: a chart-library
-// built-in (roboto/notosans/…) or an embedded Go face. Empty returns nil (the
-// library default, Roboto).
+// resolveGraphFont returns the parsed font for a graph font name (empty = the default
+// DejaVu Sans face). Graphs render their text through the chart library with this font.
 func resolveGraphFont(name string) (*truetype.Font, error) {
-	switch {
-	case name == "":
-		return nil, nil
-	case builtinGraphFonts[name]:
-		if f := charts.GetFont(name); f != nil {
-			return f, nil
-		}
-		return nil, fmt.Errorf("font %q unavailable", name)
-	case embeddedFonts[name] != nil:
-		return truetype.Parse(embeddedFonts[name])
-	default:
-		return nil, fmt.Errorf("unknown font %q", name)
+	if name == "" {
+		return truetype.Parse(dejavuSansTTF)
 	}
+	if data := embeddedFonts[name]; data != nil {
+		return truetype.Parse(data)
+	}
+	return nil, fmt.Errorf("unknown font %q", name)
 }

--- a/internal/kromgo/fonts_test.go
+++ b/internal/kromgo/fonts_test.go
@@ -1,0 +1,31 @@
+package kromgo
+
+import (
+	"testing"
+
+	"github.com/golang/freetype/truetype"
+	"golang.org/x/image/font/sfnt"
+)
+
+// TestEmbeddedFontsParse ensures every registered font parses with both the badge
+// renderer (sfnt) and the graph renderer (truetype). It guards against a vendored
+// face the renderers can't read — e.g. wiring in an @fontsource woff2 instead of a
+// static .ttf, or a corrupt asset.
+func TestEmbeddedFontsParse(t *testing.T) {
+	if len(embeddedFonts) == 0 {
+		t.Fatal("no embedded fonts registered")
+	}
+	for name, data := range embeddedFonts {
+		t.Run(name, func(t *testing.T) {
+			if len(data) == 0 {
+				t.Fatalf("font %q is empty (asset not generated?)", name)
+			}
+			if _, err := sfnt.Parse(data); err != nil {
+				t.Errorf("sfnt parse (badge renderer): %v", err)
+			}
+			if _, err := truetype.Parse(data); err != nil {
+				t.Errorf("truetype parse (graph renderer): %v", err)
+			}
+		})
+	}
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,17 +9,31 @@
       "version": "0.0.0",
       "license": "Apache-2.0",
       "dependencies": {
+        "@expo-google-fonts/comic-neue": "0.4.1",
         "@mdi/svg": "7.4.47",
+        "dejavu-fonts-ttf": "2.37.3",
         "github-markdown-css": "5.9.0",
         "marked": "18.0.4",
         "simple-icons": "16.22.0"
       }
+    },
+    "node_modules/@expo-google-fonts/comic-neue": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@expo-google-fonts/comic-neue/-/comic-neue-0.4.1.tgz",
+      "integrity": "sha512-1kYFjZeSQnGFeMnwk/B7M3p+og5eW6QZLxjMeMiZ/7TnP2IEAdYo0Gjy3XH2TpoiBHS9PAwEHaETVthVPsF09Q==",
+      "license": "MIT AND OFL-1.1"
     },
     "node_modules/@mdi/svg": {
       "version": "7.4.47",
       "resolved": "https://registry.npmjs.org/@mdi/svg/-/svg-7.4.47.tgz",
       "integrity": "sha512-WQ2gDll12T9WD34fdRFgQVgO8bag3gavrAgJ0frN4phlwdJARpE6gO1YvLEMJR0KKgoc+/Ea/A0Pp11I00xBvw==",
       "license": "Apache-2.0"
+    },
+    "node_modules/dejavu-fonts-ttf": {
+      "version": "2.37.3",
+      "resolved": "https://registry.npmjs.org/dejavu-fonts-ttf/-/dejavu-fonts-ttf-2.37.3.tgz",
+      "integrity": "sha512-f1hd7jJbeQa1VWcw+K2KrTXS50zTMaHpVC4XIKJpNcDeYR5ajMtj/iLlQDYNvLOKamUB3ARVVCf79lNwNVztSQ==",
+      "license": "SEE LICENSE IN README.md AND LICENSE"
     },
     "node_modules/github-markdown-css": {
       "version": "5.9.0",

--- a/package.json
+++ b/package.json
@@ -2,10 +2,12 @@
   "name": "kromgo-assets",
   "version": "0.0.0",
   "private": true,
-  "description": "Build-time assets embedded into the kromgo binary by cmd/genassets. Not published; managed here so Renovate keeps marked, github-markdown-css, and the Material Design Icons and Simple Icons sets up to date.",
+  "description": "Build-time assets embedded into the kromgo binary by cmd/genassets. Not published; managed here so Renovate keeps marked, github-markdown-css, the Material Design Icons and Simple Icons sets, and the DejaVu Sans and Comic Neue fonts up to date.",
   "license": "Apache-2.0",
   "dependencies": {
+    "@expo-google-fonts/comic-neue": "0.4.1",
     "@mdi/svg": "7.4.47",
+    "dejavu-fonts-ttf": "2.37.3",
     "github-markdown-css": "5.9.0",
     "marked": "18.0.4",
     "simple-icons": "16.22.0"

--- a/test/integration/gallery_test.go
+++ b/test/integration/gallery_test.go
@@ -26,7 +26,7 @@ const (
 	gdim      = "last=1h&width=480&height=200"
 )
 
-var graphFonts = []string{"roboto", "notosans", "notosans-bold", "go-regular", "go-bold", "go-medium", "go-mono"}
+var graphFonts = []string{"dejavu-sans", "dejavu-sans-bold"}
 
 // graphExamples are distinct synthetic series so each graph in the gallery has its
 // own shape and title instead of repeating one sawtooth. Every query is a


### PR DESCRIPTION
kromgo embeds two fonts, vendored via npm through the `cmd/genassets` pipeline (Renovate-tracked, not committed) and selectable by name for both badges and graphs:

- **`dejavu-sans`** / **`dejavu-sans-bold`** — the **default**: the free, metric-compatible stand-in for the **Verdana** shields.io renders with (Verdana is proprietary). Badge geometry already matches shields.io flat (**11 px text, 20 px tall**, `#555` label, rounded corners, gradient).
- **`comic-neue`** / **`comic-neue-bold`** — a second selectable face: a free Comic Sans alternative (Google Fonts, `@expo-google-fonts/comic-neue`). Opt in with `font: comic-neue`.

### Removed (vs the prior Go-font set)
- The Go family (`go-regular`/`go-bold`/`go-medium`/`go-mono`) and the chart library's `roboto`/`notosans` graph fonts are no longer selectable.
- ⚠️ **Breaking:** a config setting `font:` to any of those names now fails fast at startup (unknown font). Switch to `dejavu-sans` (or `comic-neue`).

### Why TTF, not woff2
The renderers — `sfnt` (badges → glyph paths) and `freetype/truetype` + `go-analyze/charts` (graphs) — parse **sfnt (TTF/OTF)**, not woff2 (a Brotli-compressed container). So `@fontsource` (woff2-only) isn't usable without a decoder; `dejavu-fonts-ttf` and `@expo-google-fonts/*` ship static TTFs directly.

### Notes
- `fonts_test.go` parses every embedded font with both renderers.
- No new Go module deps (stdlib `embed`); `.gitignore` + the mise `assets` outputs cover the four TTFs.

Verified: `go run ./cmd/genassets` → all four TTFs; `go build` / `go vet` / `golangci-lint` (0 issues) / `go test ./internal/kromgo/...` (+ `-tags integration` compile) all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
