### PR TITLE
feat(cache)!: add a global cache config block for Cache-Control headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,6 @@ same-named field. All keys are optional.
 
 ```yaml
 defaults:
-    cacheSeconds: 0 # Cache-Control max-age in seconds; 0 disables caching
     badge:
         font: go-regular # go-regular (default), go-bold, go-medium, go-mono
         size: 11 # badge font size in points
@@ -116,19 +115,18 @@ The gallery page itself is toggled separately at the top level — see [Gallery]
 
 Each entry under `badges:` defines an instant-value endpoint at `/badges/{id}`.
 
-| Field          | Required | Description                                                                          |
-| -------------- | -------- | ------------------------------------------------------------------------------------ |
-| `id`           | yes      | URL path segment — `cpu` → `GET /badges/cpu`                                         |
-| `query`        | yes      | PromQL expression returning a single scalar or vector value                          |
-| `title`        | no       | Display label on the badge (defaults to `id`)                                        |
-| `type`         | no       | `instant` (default) or `range` — see [Range badges](#range-badges)                   |
-| `range`        | no\*     | Range-query window when `type: range`                                                |
-| `value`        | no       | CEL expression for the displayed string — see [Value and color](#value-and-color)    |
-| `color`        | no       | CEL expression for the color — see [Value and color](#value-and-color)               |
-| `style`        | no       | `flat` (default), `flat-square`, or `plastic`                                        |
-| `icon`         | no       | An icon on the SVG badge, e.g. `mdi:server-outline` or `si:kubernetes` — see below   |
-| `gallery`      | no       | Per-badge gallery settings, e.g. `gallery: {hidden: true}` — see [Gallery](#gallery) |
-| `cacheSeconds` | no       | Override `defaults.cacheSeconds` for this badge                                      |
+| Field     | Required | Description                                                                          |
+| --------- | -------- | ------------------------------------------------------------------------------------ |
+| `id`      | yes      | URL path segment — `cpu` → `GET /badges/cpu`                                         |
+| `query`   | yes      | PromQL expression returning a single scalar or vector value                          |
+| `title`   | no       | Display label on the badge (defaults to `id`)                                        |
+| `type`    | no       | `instant` (default) or `range` — see [Range badges](#range-badges)                   |
+| `range`   | no\*     | Range-query window when `type: range`                                                |
+| `value`   | no       | CEL expression for the displayed string — see [Value and color](#value-and-color)    |
+| `color`   | no       | CEL expression for the color — see [Value and color](#value-and-color)               |
+| `style`   | no       | `flat` (default), `flat-square`, or `plastic`                                        |
+| `icon`    | no       | An icon on the SVG badge, e.g. `mdi:server-outline` or `si:kubernetes` — see below   |
+| `gallery` | no       | Per-badge gallery settings, e.g. `gallery: {hidden: true}` — see [Gallery](#gallery) |
 
 #### Icons
 
@@ -263,19 +261,18 @@ opt-in to expose range data for that query — there is no separate enable flag.
 [go-analyze/charts](https://github.com/go-analyze/charts) as **SVG** (default) or **PNG**
 (`?format=png`).
 
-| Field          | Required | Description                                                                          |
-| -------------- | -------- | ------------------------------------------------------------------------------------ |
-| `id`           | yes      | URL path segment — `cpu` → `GET /graphs/cpu`                                         |
-| `query`        | yes      | PromQL expression run as a range query                                               |
-| `title`        | no       | Display label (defaults to `id`)                                                     |
-| `maxDuration`  | no       | Cap on the requested window (overrides `defaults.graph.maxDuration`)                 |
-| `width`        | no       | Image width in px (overrides `defaults.graph.width`)                                 |
-| `height`       | no       | Image height in px (overrides `defaults.graph.height`)                               |
-| `legend`       | no       | Show the series legend (overrides `defaults.graph.legend`)                           |
-| `theme`        | no       | Color theme (overrides `defaults.graph.theme`) — see [Themes](#themes-and-fonts)     |
-| `font`         | no       | Text font (overrides `defaults.graph.font`) — see [Themes](#themes-and-fonts)        |
-| `gallery`      | no       | Per-graph gallery settings, e.g. `gallery: {hidden: true}` — see [Gallery](#gallery) |
-| `cacheSeconds` | no       | Override `defaults.cacheSeconds` for this graph                                      |
+| Field         | Required | Description                                                                          |
+| ------------- | -------- | ------------------------------------------------------------------------------------ |
+| `id`          | yes      | URL path segment — `cpu` → `GET /graphs/cpu`                                         |
+| `query`       | yes      | PromQL expression run as a range query                                               |
+| `title`       | no       | Display label (defaults to `id`)                                                     |
+| `maxDuration` | no       | Cap on the requested window (overrides `defaults.graph.maxDuration`)                 |
+| `width`       | no       | Image width in px (overrides `defaults.graph.width`)                                 |
+| `height`      | no       | Image height in px (overrides `defaults.graph.height`)                               |
+| `legend`      | no       | Show the series legend (overrides `defaults.graph.legend`)                           |
+| `theme`       | no       | Color theme (overrides `defaults.graph.theme`) — see [Themes](#themes-and-fonts)     |
+| `font`        | no       | Text font (overrides `defaults.graph.font`) — see [Themes](#themes-and-fonts)        |
+| `gallery`     | no       | Per-graph gallery settings, e.g. `gallery: {hidden: true}` — see [Gallery](#gallery) |
 
 ```yaml
 graphs:
@@ -492,29 +489,34 @@ http:
 
 ## Caching
 
-Caching has two halves, and kromgo owns the half only it can know: **how long a value stays fresh**.
-Set `cacheSeconds` (globally under `defaults` and/or per endpoint) and kromgo emits
-`Cache-Control: public, max-age=N` on successful responses and includes `cacheSeconds` in the
-shields.io endpoint JSON. Errors are always sent `no-store`. Caching is off by default
-(`cacheSeconds: 0`).
+Caching has two halves. kromgo owns the half only it can know — **how long a value stays fresh** —
+and emits a `Cache-Control` header so the other half (a browser, CDN, or GitHub's camo image proxy)
+knows how long to store the response. One policy applies to every endpoint; it is configured at the
+top level under `cache:` and is **enabled by default**.
 
 ```yaml
-defaults:
-    cacheSeconds: 300 # default for every endpoint
-
-badges:
-    - id: node_cpu_usage # changes every scrape — short TTL
-      query: "..."
-      cacheSeconds: 30
-    - id: cluster_age # changes once a day — long TTL
-      query: "..."
-      cacheSeconds: 3600
+cache:
+    enabled: true # default; false sends no-store so nothing caches the badge
+    maxAge: 300 # max-age + s-maxage in seconds (default 300); ignored when disabled
 ```
 
+- **`enabled: true` (default)** — kromgo sends `Cache-Control: public, max-age=<maxAge>, s-maxage=<maxAge>`
+  on successful responses and advertises `cacheSeconds` in the shields.io endpoint JSON. `max-age`
+  governs browser caches; `s-maxage` governs shared caches (CDNs, camo) — shields.io sets both.
+- **`enabled: false`** — kromgo sends `Cache-Control: no-cache, no-store, must-revalidate, max-age=0`.
+  Sending _no_ header is not the same as disabling caching: it lets camo/CDNs apply their own
+  aggressive default (which is why an unconfigured badge can go stale), so kromgo always sends an
+  explicit header. To turn caching off set `enabled: false` — not `maxAge: 0`, which just falls back
+  to the 300s default.
+
+Errors are always sent `no-store`. A `Cache-Control` header still isn't a hard guarantee against
+GitHub's camo proxy ([shields#221](https://github.com/badges/shields/issues/221)), but it's the
+strongest signal kromgo can send.
+
 The **other half — actually storing responses — is the edge's job**, and any cache that honors
-`Cache-Control` (a CDN, Varnish, nginx `proxy_cache`) will then cache each endpoint for exactly the
-TTL kromgo advertised. shields.io already respects `cacheSeconds`, so badges served through it are
-cached without any proxy at all.
+`Cache-Control` (a CDN, Varnish, nginx `proxy_cache`) will then cache each endpoint for the advertised
+`maxAge`. shields.io already respects `cacheSeconds`, so badges served through it are cached without
+any proxy at all.
 
 If you want the reverse proxy itself to cache, enable its HTTP cache and let it honor the origin
 headers — for example, nginx:
@@ -533,7 +535,7 @@ server {
 
 Caddy (via the [cache-handler](https://github.com/caddyserver/cache-handler) plugin), Traefik, and
 Envoy can cache too, but generally need a plugin or an external cache/CDN; the simplest setup is to
-front kromgo with a CDN and let `cacheSeconds` drive it.
+front kromgo with a CDN and let kromgo's `Cache-Control` header drive it.
 
 ## Security
 

--- a/config.schema.json
+++ b/config.schema.json
@@ -34,9 +34,6 @@
         },
         "gallery": {
           "$ref": "#/$defs/GallerySettings"
-        },
-        "cacheSeconds": {
-          "type": "integer"
         }
       },
       "additionalProperties": false,
@@ -61,11 +58,20 @@
       "additionalProperties": false,
       "type": "object"
     },
+    "Cache": {
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "maxAge": {
+          "type": "integer"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
     "Defaults": {
       "properties": {
-        "cacheSeconds": {
-          "type": "integer"
-        },
         "badge": {
           "$ref": "#/$defs/BadgeDefaults"
         },
@@ -125,9 +131,6 @@
         },
         "gallery": {
           "$ref": "#/$defs/GallerySettings"
-        },
-        "cacheSeconds": {
-          "type": "integer"
         }
       },
       "additionalProperties": false,
@@ -168,6 +171,9 @@
         },
         "gallery": {
           "$ref": "#/$defs/Gallery"
+        },
+        "cache": {
+          "$ref": "#/$defs/Cache"
         },
         "defaults": {
           "$ref": "#/$defs/Defaults"

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -19,9 +19,23 @@ const DefaultPath = "/config/config.yaml"
 type KromgoConfig struct {
 	Prometheus string   `yaml:"prometheus,omitempty" json:"prometheus,omitempty"`
 	Gallery    Gallery  `yaml:"gallery,omitempty" json:"gallery,omitempty"`
+	Cache      Cache    `yaml:"cache,omitempty" json:"cache,omitempty"`
 	Defaults   Defaults `yaml:"defaults,omitempty" json:"defaults,omitempty"`
 	Badges     []Badge  `yaml:"badges,omitempty" json:"badges,omitempty"`
 	Graphs     []Graph  `yaml:"graphs,omitempty" json:"graphs,omitempty"`
+}
+
+// Cache configures the Cache-Control headers kromgo sends with badge and graph
+// responses. Caching is enabled by default; one policy applies to every endpoint —
+// it is intentionally not configurable per badge or graph.
+type Cache struct {
+	// Enabled toggles response caching. Defaults to true. When false, kromgo sends an
+	// explicit no-store so browsers, CDNs, and GitHub's camo image proxy don't serve a
+	// stale badge.
+	Enabled *bool `yaml:"enabled,omitempty" json:"enabled,omitempty"`
+	// MaxAge is the Cache-Control max-age + s-maxage in seconds (defaults to 300).
+	// Ignored when enabled is false. To disable caching set enabled: false, not maxAge: 0.
+	MaxAge int `yaml:"maxAge,omitempty" json:"maxAge,omitempty"`
 }
 
 // Gallery configures the index gallery page served at "/".
@@ -40,8 +54,6 @@ type GallerySettings struct {
 
 // Defaults holds values applied to every endpoint, each overridable per endpoint.
 type Defaults struct {
-	// CacheSeconds is the default Cache-Control max-age (in seconds). 0 disables caching.
-	CacheSeconds int `yaml:"cacheSeconds,omitempty" json:"cacheSeconds,omitempty"`
 	// Badge holds the default badge rendering settings.
 	Badge BadgeDefaults `yaml:"badge,omitempty" json:"badge,omitempty"`
 	// Graph holds the default graph rendering settings.
@@ -102,8 +114,6 @@ type Badge struct {
 	Icon string `yaml:"icon,omitempty" json:"icon,omitempty"`
 	// Gallery holds this badge's gallery settings (e.g. hidden), overriding defaults.badge.gallery.
 	Gallery GallerySettings `yaml:"gallery,omitempty" json:"gallery,omitempty"`
-	// CacheSeconds overrides defaults.cacheSeconds for this badge.
-	CacheSeconds *int `yaml:"cacheSeconds,omitempty" json:"cacheSeconds,omitempty"`
 }
 
 // Graph defines a time-series endpoint at /graphs/{id}.
@@ -128,8 +138,6 @@ type Graph struct {
 	Font string `yaml:"font,omitempty" json:"font,omitempty"`
 	// Gallery holds this graph's gallery settings (e.g. hidden), overriding defaults.graph.gallery.
 	Gallery GallerySettings `yaml:"gallery,omitempty" json:"gallery,omitempty"`
-	// CacheSeconds overrides defaults.cacheSeconds for this graph.
-	CacheSeconds *int `yaml:"cacheSeconds,omitempty" json:"cacheSeconds,omitempty"`
 }
 
 // RangeQuery configures a windowed range query (Badge.Type == "range"). The window
@@ -221,6 +229,9 @@ func checkLegacy(data []byte) error {
 
 // validate checks defaults, then every badge and graph.
 func (c KromgoConfig) validate() error {
+	if c.Cache.MaxAge < 0 {
+		return fmt.Errorf("cache.maxAge: must not be negative")
+	}
 	if s := c.Defaults.Graph.MaxDuration; s != "" {
 		if _, err := ParseDuration(s); err != nil {
 			return fmt.Errorf("defaults.graph.maxDuration: %w", err)

--- a/internal/kromgo/graph.go
+++ b/internal/kromgo/graph.go
@@ -53,7 +53,7 @@ func (h *Handler) serveGraph(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	metricLabel = id
-	setCache(w, graph.cacheSeconds)
+	h.cache.apply(w)
 
 	start, end, step, ok := h.validateGraphAccess(w, r, graph)
 	if !ok {

--- a/internal/kromgo/handler.go
+++ b/internal/kromgo/handler.go
@@ -21,6 +21,7 @@ const (
 // Handler serves badge and graph endpoints backed by Prometheus queries.
 type Handler struct {
 	cfg    config.KromgoConfig
+	cache  cachePolicy
 	badges map[string]*resolvedBadge
 	graphs map[string]*resolvedGraph
 	prom   *prometheus.Client
@@ -59,7 +60,7 @@ func New(cfg config.KromgoConfig, prom *prometheus.Client) (*Handler, error) {
 		graphs[g.ID] = rg
 	}
 
-	return &Handler{cfg: cfg, badges: badges, graphs: graphs, prom: prom, gen: gen}, nil
+	return &Handler{cfg: cfg, cache: resolveCache(cfg.Cache), badges: badges, graphs: graphs, prom: prom, gen: gen}, nil
 }
 
 // Mux returns the application router: the index page and per-type endpoints.

--- a/internal/kromgo/handler_test.go
+++ b/internal/kromgo/handler_test.go
@@ -262,47 +262,51 @@ func TestServeBadge_Expressions(t *testing.T) {
 func TestCacheControl(t *testing.T) {
 	t.Parallel()
 
-	t.Run("per-endpoint override and global default", func(t *testing.T) {
+	// Caching is global (not per endpoint) and on by default.
+	t.Run("enabled", func(t *testing.T) {
 		t.Parallel()
-		cfg := config.KromgoConfig{
-			Defaults: config.Defaults{CacheSeconds: 60}, // global default
-			Badges: []config.Badge{
-				{ID: "fast", Query: "q"},
-				{ID: "slow", Query: "q", CacheSeconds: new(3600)},
-			},
-		}
-		srv := mockProm(t, "1", nil)
-		h := newHandlerForTest(t, cfg, srv.URL)
-
 		cases := []struct {
-			name, id, wantCache, wantBody string
+			name      string
+			cache     config.Cache
+			wantCache string
+			wantBody  string
 		}{
-			{"global default", "fast", "public, max-age=60", `"cacheSeconds":60`},
-			{"per-endpoint override", "slow", "public, max-age=3600", `"cacheSeconds":3600`},
+			{"on by default at the default max-age", config.Cache{}, "public, max-age=300, s-maxage=300", `"cacheSeconds":300`},
+			{"custom max-age", config.Cache{MaxAge: 3600}, "public, max-age=3600, s-maxage=3600", `"cacheSeconds":3600`},
+			{"enabled with max-age unset falls back to default", config.Cache{Enabled: new(true)}, "public, max-age=300, s-maxage=300", `"cacheSeconds":300`},
 		}
 		for _, tc := range cases {
 			t.Run(tc.name, func(t *testing.T) {
 				t.Parallel()
-				w := promtest.Get(t, h.Mux(), "/badges/"+tc.id+"?format=shields")
+				cfg := config.KromgoConfig{Cache: tc.cache, Badges: []config.Badge{{ID: "cpu", Query: "q"}}}
+				srv := mockProm(t, "1", nil)
+				h := newHandlerForTest(t, cfg, srv.URL)
+				w := promtest.Get(t, h.Mux(), "/badges/cpu?format=shields")
 				assert.Equal(t, tc.wantCache, w.Header().Get("Cache-Control"))
 				assert.Contains(t, w.Body.String(), tc.wantBody)
 			})
 		}
 	})
 
-	t.Run("disabled by default", func(t *testing.T) {
+	t.Run("disabled sends no-store", func(t *testing.T) {
 		t.Parallel()
+		cfg := config.KromgoConfig{
+			Cache:  config.Cache{Enabled: new(false)},
+			Badges: []config.Badge{{ID: "cpu", Query: "q"}},
+		}
 		srv := mockProm(t, "17.5", nil)
-		h := newHandlerForTest(t, baseConfig(), srv.URL) // no CacheSeconds
-		w := promtest.Get(t, h.Mux(), "/badges/cpu")
-		assert.Empty(t, w.Header().Get("Cache-Control"))
+		h := newHandlerForTest(t, cfg, srv.URL)
+		w := promtest.Get(t, h.Mux(), "/badges/cpu?format=shields")
+		// enabled: false sends an explicit no-store (not an empty header) so camo/CDNs don't cache.
+		assert.Equal(t, "no-cache, no-store, must-revalidate, max-age=0", w.Header().Get("Cache-Control"))
+		// cacheSeconds is 0 (omitempty) in the JSON when caching is off.
+		assert.NotContains(t, w.Body.String(), "cacheSeconds")
 	})
 
 	t.Run("errors not cached", func(t *testing.T) {
 		t.Parallel()
 		cfg := config.KromgoConfig{
-			Defaults: config.Defaults{CacheSeconds: 60},
-			Graphs:   []config.Graph{{ID: "cpu", Query: "q", MaxDuration: "24h"}},
+			Graphs: []config.Graph{{ID: "cpu", Query: "q", MaxDuration: "24h"}},
 		}
 		srv := mockProm(t, "1", nil)
 		h := newHandlerForTest(t, cfg, srv.URL)

--- a/internal/kromgo/instant.go
+++ b/internal/kromgo/instant.go
@@ -47,7 +47,7 @@ func (h *Handler) serveBadge(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	metricLabel = id
-	setCache(w, badge.cacheSeconds)
+	h.cache.apply(w)
 
 	value, err := h.queryValue(r.Context(), badge)
 	if err != nil {
@@ -79,7 +79,7 @@ func (h *Handler) serveBadge(w http.ResponseWriter, r *http.Request) {
 	switch format {
 	case formatShields:
 		writeJSONOr(w, log, id, EndpointResponse{
-			SchemaVersion: 1, Label: title, Message: message, Color: color, CacheSeconds: badge.cacheSeconds,
+			SchemaVersion: 1, Label: title, Message: message, Color: color, CacheSeconds: h.cache.seconds,
 		})
 	case formatJSON:
 		writeJSONOr(w, log, id, BadgeJSON{

--- a/internal/kromgo/metric.go
+++ b/internal/kromgo/metric.go
@@ -18,26 +18,24 @@ const (
 )
 
 // resolvedBadge is a config.Badge with its per-request values resolved once at
-// startup: the compiled value/color CEL programs, effective style and cache TTL,
-// and (for type: range) the parsed range-query window. This keeps compilation off
-// the request hot path and surfaces bad config at startup.
+// startup: the compiled value/color CEL programs, effective style, and (for type:
+// range) the parsed range-query window. This keeps compilation off the request hot
+// path and surfaces bad config at startup.
 type resolvedBadge struct {
 	config.Badge
-	valueProg    cel.Program // compiled Value expression (always set)
-	colorProg    cel.Program // compiled Color expression; nil when none
-	cacheSeconds int
-	style        string
-	iconPath     string      // resolved SVG path data for Icon; "" when none
-	rangeQuery   *rangeQuery // non-nil when Type == range
+	valueProg  cel.Program // compiled Value expression (always set)
+	colorProg  cel.Program // compiled Color expression; nil when none
+	style      string
+	iconPath   string      // resolved SVG path data for Icon; "" when none
+	rangeQuery *rangeQuery // non-nil when Type == range
 }
 
-// resolvedGraph is a config.Graph with its cache TTL, window cap, and default
-// sparkline parameters resolved once at startup.
+// resolvedGraph is a config.Graph with its window cap and default sparkline
+// parameters resolved once at startup.
 type resolvedGraph struct {
 	config.Graph
-	cacheSeconds int
-	maxDuration  time.Duration // 0 means unlimited
-	defaults     chartParams   // request query params override these
+	maxDuration time.Duration // 0 means unlimited
+	defaults    chartParams   // request query params override these
 }
 
 // rangeQuery is the resolved window for a type: range badge.
@@ -56,10 +54,9 @@ func resolveBadge(b config.Badge, def config.Defaults, env *cel.Env) (*resolvedB
 	}
 
 	rb := &resolvedBadge{
-		Badge:        b,
-		cacheSeconds: firstSet(def.CacheSeconds, b.CacheSeconds),
-		style:        cmp.Or(b.Style, def.Badge.Style, config.StyleFlat),
-		iconPath:     iconPath,
+		Badge:    b,
+		style:    cmp.Or(b.Style, def.Badge.Style, config.StyleFlat),
+		iconPath: iconPath,
 	}
 
 	if rb.valueProg, err = compileStringExpr(env, b.ID, "value", cmp.Or(b.Value, defaultValueExpr)); err != nil {
@@ -91,9 +88,8 @@ func resolveGraph(g config.Graph, def config.Defaults) (*resolvedGraph, error) {
 	}
 
 	rg := &resolvedGraph{
-		Graph:        g,
-		cacheSeconds: firstSet(def.CacheSeconds, g.CacheSeconds),
-		maxDuration:  defaultGraphMaxDuration,
+		Graph:       g,
+		maxDuration: defaultGraphMaxDuration,
 		defaults: chartParams{
 			width:  cmp.Or(g.Width, def.Graph.Width, defaultGraphWidth),
 			height: cmp.Or(g.Height, def.Graph.Height, defaultGraphHeight),

--- a/internal/kromgo/response.go
+++ b/internal/kromgo/response.go
@@ -1,10 +1,13 @@
 package kromgo
 
 import (
+	"cmp"
 	"encoding/json"
 	"fmt"
 	"log/slog"
 	"net/http"
+
+	"github.com/home-operations/kromgo/internal/config"
 )
 
 // Response MIME types.
@@ -41,12 +44,40 @@ func writeSVG(w http.ResponseWriter, svg []byte) {
 	_, _ = w.Write(svg)
 }
 
-// setCache applies a successful response's cache policy; writeError later overrides
-// it with no-store on failures.
-func setCache(w http.ResponseWriter, cacheSeconds int) {
-	if cacheSeconds > 0 {
-		w.Header().Set("Cache-Control", fmt.Sprintf("public, max-age=%d", cacheSeconds))
+// defaultCacheMaxAge is the Cache-Control max-age / s-maxage (in seconds) applied
+// when caching is enabled and cache.maxAge is unset.
+const defaultCacheMaxAge = 300
+
+// cachePolicy is the global, precomputed Cache-Control policy: the header value sent
+// on successful responses and the cacheSeconds advertised in the shields.io JSON. It
+// is resolved once from config (see resolveCache), the same for every endpoint.
+type cachePolicy struct {
+	control string // Cache-Control header value for successful responses
+	seconds int    // cacheSeconds reported in the shields.io JSON; 0 when caching is off
+}
+
+// resolveCache turns the global cache config into a fixed policy. Caching is on by
+// default; enabled: false sends an explicit no-store. Sending no header would NOT
+// mean "no caching" — it lets GitHub's camo proxy / CDNs apply their own aggressive
+// default, which is why badges go stale. A header still isn't a hard guarantee
+// against camo (badges/shields#221), but it's the strongest signal we can send.
+func resolveCache(c config.Cache) cachePolicy {
+	if c.Enabled != nil && !*c.Enabled {
+		return cachePolicy{control: "no-cache, no-store, must-revalidate, max-age=0"}
 	}
+	maxAge := cmp.Or(c.MaxAge, defaultCacheMaxAge)
+	// max-age governs browser caches; s-maxage governs shared caches (CDNs and GitHub's
+	// camo image proxy) — the ones that cache README badges. shields.io sets both.
+	return cachePolicy{
+		control: fmt.Sprintf("public, max-age=%d, s-maxage=%d", maxAge, maxAge),
+		seconds: maxAge,
+	}
+}
+
+// apply sets the resolved Cache-Control header on a successful response; writeError
+// later overrides it with no-store on failures.
+func (p cachePolicy) apply(w http.ResponseWriter) {
+	w.Header().Set("Cache-Control", p.control)
 }
 
 // writeJSONOr writes v as JSON, falling back to a 500 error response on marshal failure.


### PR DESCRIPTION
**Problem:** GitHub's camo image proxy aggressively caches README badges, and kromgo sent **no `Cache-Control` header** on the default path — so camo/CDNs applied their own aggressive default and badges went stale. There was also no single place to tune caching.

**This PR** adds a top-level `cache:` block that controls caching **globally** (one policy for every endpoint — intentionally not per badge or graph) and is **enabled by default**:

```yaml
cache:
    enabled: true # default; false sends no-store so nothing caches the badge
    maxAge: 300 # max-age + s-maxage in seconds (default 300); ignored when disabled
```

- **`enabled: true` (default)** → `Cache-Control: public, max-age=<maxAge>, s-maxage=<maxAge>` on success, and `cacheSeconds` in the shields.io JSON. `s-maxage` is what governs *shared* caches (CDNs, camo) — kromgo previously set only `max-age`; shields.io sets both.
- **`enabled: false`** → `Cache-Control: no-cache, no-store, must-revalidate, max-age=0`. Sending *no* header is not "no caching" — it's exactly what let camo cache stale badges, so kromgo now always sends an explicit one. (To disable, set `enabled: false` — not `maxAge: 0`, which falls back to the 300s default.)
- **Errors** stay `no-store`.

The policy is resolved once at startup and reused — no per-request work.

**Borrowed from [badges/shields](https://github.com/badges/shields):** set both `max-age` (browser) **and** `s-maxage` (shared/CDN), and keep a sane default TTL rather than relying on the proxy's.

**Honest caveat:** a `Cache-Control` header still isn't a hard guarantee against camo ([shields#221](https://github.com/badges/shields/issues/221)) — but an explicit header is the strongest lever available and strictly better than the previous no-header default.

**⚠️ Breaking:** removes `defaults.cacheSeconds` and the per-badge / per-graph `cacheSeconds`. Config parsing is strict (unknown keys fail to load), so a config using them must migrate — move the value to the top-level `cache.maxAge`, or set `cache.enabled: false` to turn caching off.

Verified: `go build` / `go vet` / `golangci-lint` (0 issues) / `go test ./...` green; handler tests cover enabled (default + custom max-age), disabled (no-store, no `cacheSeconds` in JSON), and errors; `config.schema.json` regenerated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
