### PR TITLE
feat: graph valueExpr for y-axis label formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -322,6 +322,7 @@ opt-in to expose range data for that query — there is no separate enable flag.
 | `legend`      | no       | Show the series legend (overrides `defaults.graph.legend`)                           |
 | `theme`       | no       | Color theme (overrides `defaults.graph.theme`) — see [Themes](#themes-and-fonts)     |
 | `font`        | no       | Text font (overrides `defaults.graph.font`) — see [Themes](#themes-and-fonts)        |
+| `valueExpr`   | no       | CEL expression formatting the y-axis labels (overrides `defaults.graph.valueExpr`)   |
 | `gallery`     | no       | Per-graph gallery settings, e.g. `gallery: {hidden: true}` — see [Gallery](#gallery) |
 
 ```yaml
@@ -331,6 +332,22 @@ graphs:
       maxDuration: "30d"
       width: 800
       theme: catppuccin-mocha
+```
+
+By default the y-axis labels use the chart library's numeric formatting, which can show fractional
+ticks (e.g. `42.8`) even when the underlying values are whole numbers. `valueExpr` overrides this:
+like a badge's [`valueExpr`](#value-and-color), it's a CEL expression over `result` (here, the y-axis
+tick value) that returns the label string, with the same [humanizer functions](#value-and-color)
+available. It formats **only the y-axis labels** — the legend shows series names, and `?format=json`
+keeps the raw numbers.
+
+```yaml
+graphs:
+    - id: cluster_pod_count_graph
+      title: Running Pods
+      query: sum(kube_pod_status_phase{phase="Running"})
+      maxDuration: 7d
+      valueExpr: string(int(result)) + " pods" # integer ticks; drop the suffix for bare integers
 ```
 
 The time window is chosen by these query parameters:

--- a/charts/kromgo/values.yaml
+++ b/charts/kromgo/values.yaml
@@ -44,6 +44,7 @@ config:
   #     style: flat
   #   graph:
   #     theme: dark
+  #     valueExpr: string(int(result)) # integer y-axis labels for every graph
 
   # Instant-value endpoints served at /badges/{id}.
   badges: []
@@ -60,6 +61,13 @@ config:
   #     title: CPU %
   #     query: (time() % 1800) / 18
   #     theme: dark
+  #   - id: pods
+  #     title: Running Pods
+  #     query: sum(kube_pod_status_phase{phase="Running"})
+  #     # valueExpr formats the y-axis labels (a CEL expression over `result`, with
+  #     # the same humanizers as a badge) — here integer counts instead of the
+  #     # default fractional ticks like 42.8.
+  #     valueExpr: string(int(result)) + " pods"
 
 # Server tuning — kromgo's runtime environment variables (distinct from the
 # config file above). SERVER_HOST/PORT and HEALTH_HOST/PORT are fixed by the

--- a/config.schema.json
+++ b/config.schema.json
@@ -135,6 +135,9 @@
         "font": {
           "type": "string"
         },
+        "valueExpr": {
+          "type": "string"
+        },
         "gallery": {
           "$ref": "#/$defs/GallerySettings"
         }
@@ -161,6 +164,9 @@
           "type": "string"
         },
         "font": {
+          "type": "string"
+        },
+        "valueExpr": {
           "type": "string"
         },
         "gallery": {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -89,6 +89,9 @@ type GraphDefaults struct {
 	Theme string `yaml:"theme,omitempty" json:"theme,omitempty"`
 	// Font selects the text font: dejavu-sans (default), dejavu-sans-bold, comic-neue, or comic-neue-bold.
 	Font string `yaml:"font,omitempty" json:"font,omitempty"`
+	// ValueExpr is the default y-axis label formatter (a CEL expression over `result`)
+	// for graphs — see Graph.ValueExpr.
+	ValueExpr string `yaml:"valueExpr,omitempty" json:"valueExpr,omitempty"`
 	// Gallery is the default gallery visibility for graphs.
 	Gallery GallerySettings `yaml:"gallery,omitempty" json:"gallery,omitempty"`
 }
@@ -143,6 +146,13 @@ type Graph struct {
 	Theme string `yaml:"theme,omitempty" json:"theme,omitempty"`
 	// Font overrides defaults.graph.font for this graph.
 	Font string `yaml:"font,omitempty" json:"font,omitempty"`
+	// ValueExpr is a CEL expression that formats the y-axis tick labels: it receives
+	// `result` (the tick value, a double) and returns the displayed string, e.g.
+	// `string(int(result))` for integers or `humanizeBytes(result)`. The same
+	// functions as a badge's valueExpr are available, but only `result` is meaningful
+	// (an axis tick has no labels). Empty uses the chart's default numeric formatting.
+	// Overrides defaults.graph.valueExpr.
+	ValueExpr string `yaml:"valueExpr,omitempty" json:"valueExpr,omitempty"`
 	// Gallery holds this graph's gallery settings (e.g. hidden), overriding defaults.graph.gallery.
 	Gallery GallerySettings `yaml:"gallery,omitempty" json:"gallery,omitempty"`
 }

--- a/internal/kromgo/chart.go
+++ b/internal/kromgo/chart.go
@@ -31,6 +31,9 @@ type chartParams struct {
 	title  string         // chart title, rendered top-left
 	font   *truetype.Font // nil uses the chart library's default font
 	format string         // "svg" (default) or "png"
+	// valueFormatter renders y-axis tick values to strings (from the graph's
+	// valueExpr). nil uses the chart library's default numeric formatting.
+	valueFormatter func(float64) string
 }
 
 // withOverrides returns the graph's default params with request query parameters
@@ -134,6 +137,11 @@ func renderChart(matrix model.Matrix, p chartParams) ([]byte, error) {
 	} else {
 		hide := false
 		opt.Legend.Show = &hide
+	}
+	// A graph's valueExpr (if any) formats the y-axis tick labels — e.g. integers or
+	// humanized units in place of the default 2-decimal numbers.
+	if p.valueFormatter != nil {
+		opt.YAxis = []charts.YAxisOption{{ValueFormatter: p.valueFormatter}}
 	}
 
 	// Font is set on the painter (the non-deprecated default-font hook). resolveGraphFont

--- a/internal/kromgo/chart_test.go
+++ b/internal/kromgo/chart_test.go
@@ -47,6 +47,23 @@ func TestRenderChart_Title(t *testing.T) {
 	assert.Contains(t, string(svg), "CPU usage")
 }
 
+func TestRenderChart_ValueFormatter(t *testing.T) {
+	t.Parallel()
+	// A graph's valueExpr becomes the y-axis ValueFormatter; a distinctive suffix on
+	// every tick label proves it reaches the rendered SVG.
+	svg, err := renderChart(makeMatrix([][]float64{{10, 25, 15, 40, 30}}),
+		chartParams{width: 400, height: 150, format: formatSVG,
+			valueFormatter: func(f float64) string { return fmt.Sprintf("%dpods", int(f)) }})
+	require.NoError(t, err)
+	assert.Contains(t, string(svg), "pods", "y-axis ticks are formatted by valueFormatter")
+
+	// Without a formatter the marker is absent (the library's default numeric labels).
+	plain, err := renderChart(makeMatrix([][]float64{{10, 25, 15, 40, 30}}),
+		chartParams{width: 400, height: 150, format: formatSVG})
+	require.NoError(t, err)
+	assert.NotContains(t, string(plain), "pods")
+}
+
 func TestRenderChart_PNG(t *testing.T) {
 	t.Parallel()
 	png, err := renderChart(makeMatrix([][]float64{{10, 25, 15, 40, 30}}),

--- a/internal/kromgo/graph_query_test.go
+++ b/internal/kromgo/graph_query_test.go
@@ -119,6 +119,8 @@ func TestParseTimeParam(t *testing.T) {
 
 func TestResolveGraph_MaxDuration(t *testing.T) {
 	t.Parallel()
+	env, err := newCELEnv()
+	require.NoError(t, err)
 	cases := []struct {
 		name  string
 		graph config.Graph
@@ -133,7 +135,7 @@ func TestResolveGraph_MaxDuration(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			rg, err := resolveGraph(tc.graph, tc.def)
+			rg, err := resolveGraph(tc.graph, tc.def, env)
 			require.NoError(t, err)
 			assert.Equal(t, tc.want, rg.maxDuration)
 		})
@@ -142,18 +144,55 @@ func TestResolveGraph_MaxDuration(t *testing.T) {
 
 func TestResolveGraph_InvalidTheme(t *testing.T) {
 	t.Parallel()
-	_, err := resolveGraph(config.Graph{ID: "t", Query: "q", Theme: "nope"}, config.Defaults{})
+	env, err := newCELEnv()
+	require.NoError(t, err)
+	_, err = resolveGraph(config.Graph{ID: "t", Query: "q", Theme: "nope"}, config.Defaults{}, env)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "theme")
 }
 
 func TestResolveGraph_DefaultParams(t *testing.T) {
 	t.Parallel()
-	rg, err := resolveGraph(config.Graph{ID: "t"}, config.Defaults{})
+	env, err := newCELEnv()
+	require.NoError(t, err)
+	rg, err := resolveGraph(config.Graph{ID: "t"}, config.Defaults{}, env)
 	require.NoError(t, err)
 	assert.Equal(t, defaultGraphWidth, rg.defaults.width)
 	assert.Equal(t, defaultGraphHeight, rg.defaults.height)
 	assert.True(t, rg.defaults.legend, "legend defaults to true")
+	assert.Nil(t, rg.defaults.valueFormatter, "no valueExpr ⇒ default numeric formatting")
+}
+
+func TestResolveGraph_ValueExpr(t *testing.T) {
+	t.Parallel()
+	env, err := newCELEnv()
+	require.NoError(t, err)
+
+	// A per-graph valueExpr compiles into a y-axis tick formatter.
+	rg, err := resolveGraph(config.Graph{ID: "t", Query: "q", ValueExpr: `string(int(result)) + " pods"`}, config.Defaults{}, env)
+	require.NoError(t, err)
+	require.NotNil(t, rg.defaults.valueFormatter)
+	assert.Equal(t, "42 pods", rg.defaults.valueFormatter(42.0))
+	assert.Equal(t, "42 pods", rg.defaults.valueFormatter(42.7), "int() truncates the float tick")
+
+	// defaults.graph.valueExpr applies when the graph doesn't set its own.
+	rg, err = resolveGraph(config.Graph{ID: "t", Query: "q"}, config.Defaults{Graph: config.GraphDefaults{ValueExpr: "humanizeBytes(result)"}}, env)
+	require.NoError(t, err)
+	require.NotNil(t, rg.defaults.valueFormatter)
+	assert.Equal(t, "1.5MB", rg.defaults.valueFormatter(1500000))
+
+	// A per-graph valueExpr overrides the default.
+	rg, err = resolveGraph(config.Graph{ID: "t", Query: "q", ValueExpr: "string(int(result))"}, config.Defaults{Graph: config.GraphDefaults{ValueExpr: "humanizeBytes(result)"}}, env)
+	require.NoError(t, err)
+	assert.Equal(t, "1500000", rg.defaults.valueFormatter(1500000))
+
+	// A malformed expression fails at resolve (startup), not on a request.
+	_, err = resolveGraph(config.Graph{ID: "t", Query: "q", ValueExpr: "nope("}, config.Defaults{}, env)
+	require.Error(t, err)
+
+	// An expression that compiles but returns a non-string is rejected too.
+	_, err = resolveGraph(config.Graph{ID: "t", Query: "q", ValueExpr: "result + 1.0"}, config.Defaults{}, env)
+	require.Error(t, err)
 }
 
 func TestResolveBadge_InvalidExprFailsFast(t *testing.T) {

--- a/internal/kromgo/handler.go
+++ b/internal/kromgo/handler.go
@@ -53,7 +53,7 @@ func New(cfg config.KromgoConfig, prom *prometheus.Client) (*Handler, error) {
 
 	graphs := make(map[string]*resolvedGraph, len(cfg.Graphs))
 	for _, g := range cfg.Graphs {
-		rg, err := resolveGraph(g, cfg.Defaults)
+		rg, err := resolveGraph(g, cfg.Defaults, env)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/kromgo/metric.go
+++ b/internal/kromgo/metric.go
@@ -3,6 +3,7 @@ package kromgo
 import (
 	"cmp"
 	"fmt"
+	"strconv"
 	"time"
 
 	"github.com/google/cel-go/cel"
@@ -85,7 +86,7 @@ func resolveBadge(b config.Badge, def config.Defaults, env *cel.Env) (*resolvedB
 }
 
 // resolveGraph precomputes a graph's cache TTL, window cap, and default parameters.
-func resolveGraph(g config.Graph, def config.Defaults) (*resolvedGraph, error) {
+func resolveGraph(g config.Graph, def config.Defaults, env *cel.Env) (*resolvedGraph, error) {
 	theme := cmp.Or(g.Theme, def.Graph.Theme)
 	if theme != "" && !validTheme(theme) {
 		return nil, fmt.Errorf("graph %q: unknown theme %q", g.ID, theme)
@@ -115,6 +116,22 @@ func resolveGraph(g config.Graph, def config.Defaults) (*resolvedGraph, error) {
 			return nil, fmt.Errorf("graph %q maxDuration: %w", g.ID, err)
 		}
 		rg.maxDuration = d
+	}
+	if expr := cmp.Or(g.ValueExpr, def.Graph.ValueExpr); expr != "" {
+		prog, err := compileStringExpr(env, g.ID, "value", expr)
+		if err != nil {
+			return nil, err
+		}
+		// Format each y-axis tick by evaluating the expression with result = the tick
+		// value (an axis tick has no series, so no labels). A runtime eval error
+		// degrades to a plain number rather than failing the whole render.
+		rg.defaults.valueFormatter = func(f float64) string {
+			s, err := evalStringExpr(prog, f, nil)
+			if err != nil {
+				return strconv.FormatFloat(f, 'f', -1, 64)
+			}
+			return s
+		}
 	}
 	return rg, nil
 }


### PR DESCRIPTION
## What

Adds a `valueExpr` to graphs (and `defaults.graph`) that formats the **y-axis tick labels** — a CEL expression over `result` (the tick value), exactly like a badge's `valueExpr` and with the same humanizer functions.

## Why

Some graphs don't need floats — a "Running Pods" count should read as `42`, not `42.8`. The default y-axis formatter (`go-analyze/charts`) renders 2-decimal values, so a small range like 41–46 produces fractional ticks.

## Before / after

For `sum(kube_pod_status_phase{phase="Running"})` with `valueExpr: string(int(result)) + " pods"`:

| default y-axis | with `valueExpr` |
| --- | --- |
| `47, 45.6, 44.2, 42.8, 41.4, 40` | `47 pods, 45 pods, 44 pods, 42 pods, 41 pods, 40 pods` |

```yaml
graphs:
  - id: cluster_pod_count_graph
    title: Running Pods
    query: sum(kube_pod_status_phase{phase="Running"})
    valueExpr: string(int(result)) + " pods"   # drop the suffix for bare integers
```

## How

- New `Graph.ValueExpr` / `GraphDefaults.ValueExpr` config fields.
- Compiled at startup in `resolveGraph` (reusing the badge CEL env + `compileStringExpr`), so a malformed expression fails fast rather than on a request.
- Wired to the chart's y-axis `ValueFormatter`; a runtime eval error degrades to a plain number.
- **Config-only** — not settable via query string, so there's no arbitrary-CEL surface.
- Formats only the y-axis labels; the legend keeps series names and `?format=json` keeps the raw numbers.

## Chart

`charts/kromgo/values.yaml` now showcases `valueExpr` in the `defaults.graph` and `graphs` examples. The ConfigMap renders `.Values.config` verbatim, so no template change was needed.

## Tests

- `TestResolveGraph_ValueExpr` — per-graph + `defaults.graph` + override + invalid/non-string expression errors.
- `TestRenderChart_ValueFormatter` — the formatter reaches the rendered SVG.
- `config.schema.json` regenerated; full unit suite, e2e, and golangci-lint all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
