### PR TITLE
feat(chart): disable ServiceAccount token automount by default

### DIFF
--- a/charts/kromgo/values.yaml
+++ b/charts/kromgo/values.yaml
@@ -99,7 +99,10 @@ secret:
 
 serviceAccount:
   create: true
-  automount: true
+  # kromgo talks only to Prometheus over HTTP, never to the Kubernetes API, so it
+  # has no use for a mounted ServiceAccount token. Disabled by default for least
+  # privilege; set true only if you add sidecars/tooling that need API access.
+  automount: false
   annotations: {}
   name: ""
 


### PR DESCRIPTION
## What

Defaults `serviceAccount.automount` to **`false`**, so kromgo's pods no longer mount a ServiceAccount token.

## Why

kromgo only queries Prometheus over HTTP — it never talks to the Kubernetes API. The auto-mounted SA token is therefore dead weight and needless attack surface, especially for a component designed to face the public web. Least privilege by default.

The chart already wires `serviceAccount.automount` to both the ServiceAccount and the pod spec, so this is a one-line default flip. Anyone who adds sidecars/tooling that need API access can set `serviceAccount.automount: true`.

## Verified

`helm lint` clean. Default render sets it on both objects:

```
# ServiceAccount + Pod spec
automountServiceAccountToken: false
```

`--set serviceAccount.automount=true` restores `true` on both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
