### PR TITLE
fix(graph): round y-axis tick values (PreferNiceIntervals)

### DIFF
--- a/internal/kromgo/badge_test.go
+++ b/internal/kromgo/badge_test.go
@@ -89,6 +89,53 @@ func TestBadgeRender_IconNoLabel(t *testing.T) {
 	assert.Contains(t, light, `<rect x="0" `, "the single message segment spans from the badge's left edge")
 }
 
+// TestRenderBadge_ConfigTable renders representative badge configs end-to-end
+// (config → resolveBadge → evaluate → render). The value text is drawn as glyph
+// paths, but also appears verbatim in the accessible name (aria-label / <title>),
+// which is what we assert — guarding the value/color expression wiring per config.
+func TestRenderBadge_ConfigTable(t *testing.T) {
+	t.Parallel()
+	env, err := newCELEnv()
+	require.NoError(t, err)
+	gen, err := newBadgeRenderer(config.BadgeDefaults{})
+	require.NoError(t, err)
+
+	cases := []struct {
+		name  string
+		badge config.Badge
+		value float64
+		want  string // expected value text in the rendered badge's accessible name
+	}{
+		{"percent + threshold color", config.Badge{ID: "cpu", Query: "q", ValueExpr: `string(int(result)) + "%"`, ColorExpr: `result <= 80.0 ? "green" : "red"`}, 42, "42%"},
+		{"humanized bytes", config.Badge{ID: "mem", Query: "q", ValueExpr: `humanizeBytes(result)`}, 1.5e9, "1.5GB"},
+		{"static string", config.Badge{ID: "ver", Query: "q", ValueExpr: `"v1.2.3"`, ColorExpr: `"blue"`}, 1, "v1.2.3"},
+		{"colorScale", config.Badge{ID: "cov", Query: "q", ValueExpr: `humanizeFloat(result) + "%"`, ColorExpr: `colorScale(result, [80.0, 90.0], ["red", "yellow", "green"])`}, 87, "87%"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			rb, err := resolveBadge(tc.badge, config.Defaults{}, env)
+			require.NoError(t, err)
+			msg, err := evalStringExpr(rb.valueProg, tc.value, nil)
+			require.NoError(t, err)
+			var color string
+			if rb.colorProg != nil {
+				color, err = evalStringExpr(rb.colorProg, tc.value, nil)
+				require.NoError(t, err)
+			}
+			label := rb.Title
+			if label == "" && rb.iconPath == "" {
+				label = rb.ID
+			}
+			svg := string(gen.render(badgeSpec{
+				style: rb.style, iconPath: rb.iconPath, label: label,
+				message: msg, color: color, labelColor: rb.labelColor, id: rb.ID,
+			}))
+			assert.Contains(t, svg, tc.want, "rendered value should appear in the badge's accessible name")
+		})
+	}
+}
+
 func TestBadgeRender_Accessibility(t *testing.T) {
 	t.Parallel()
 	r, err := newBadgeRenderer(config.BadgeDefaults{})

--- a/internal/kromgo/chart.go
+++ b/internal/kromgo/chart.go
@@ -138,11 +138,17 @@ func renderChart(matrix model.Matrix, p chartParams) ([]byte, error) {
 		hide := false
 		opt.Legend.Show = &hide
 	}
-	// A graph's valueExpr (if any) formats the y-axis tick labels — e.g. integers or
-	// humanized units in place of the default 2-decimal numbers.
+	// Ask the chart library for round y-axis tick values (e.g. 25/30/35/40/45 rather
+	// than dividing the range evenly into 25/29.39/33.78/…). Without this the ticks
+	// land on arbitrary floats, which a valueExpr like `string(result)` then prints at
+	// full precision ("46.9405%"). A graph's valueExpr (if any) then formats those
+	// values — integers or humanized units in place of the default 2-decimal numbers.
+	niceIntervals := true
+	yAxis := charts.YAxisOption{PreferNiceIntervals: &niceIntervals}
 	if p.valueFormatter != nil {
-		opt.YAxis = []charts.YAxisOption{{ValueFormatter: p.valueFormatter}}
+		yAxis.ValueFormatter = p.valueFormatter
 	}
+	opt.YAxis = []charts.YAxisOption{yAxis}
 
 	// Font is set on the painter (the non-deprecated default-font hook). resolveGraphFont
 	// always returns a face (DejaVu Sans by default), so p.font is never nil here.

--- a/internal/kromgo/chart_test.go
+++ b/internal/kromgo/chart_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/home-operations/kromgo/internal/config"
 	"github.com/prometheus/common/model"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -77,6 +78,45 @@ func TestRenderChart_NiceYAxisTicks(t *testing.T) {
 	require.NoError(t, err)
 	assert.NotRegexp(t, `>\d+\.\d{3,}<`, string(svg),
 		"y-axis ticks should be round, not full-precision floats like 46.9405")
+}
+
+// TestRenderGraph_ConfigTable renders representative graph configs end-to-end
+// (config → resolveGraph → renderChart) and checks the y-axis labels: each
+// valueExpr's units appear, and — whatever the formatter — ticks stay round (no
+// full-precision floats), guarding the formatting regressions this package has hit.
+func TestRenderGraph_ConfigTable(t *testing.T) {
+	t.Parallel()
+	env, err := newCELEnv()
+	require.NoError(t, err)
+
+	cpu := [][]float64{{25.3, 46.94, 33.1, 41.5, 28.4, 44.0}} // non-round CPU% range
+	mem := [][]float64{{1.5e9, 2.1e9, 1.2e9, 1.8e9, 2.4e9}}   // bytes
+
+	cases := []struct {
+		name      string
+		valueExpr string
+		data      [][]float64
+		want      []string // substrings that must appear in the rendered SVG
+	}{
+		{"default formatter", "", cpu, nil},
+		{"percent via string", `string(result) + "%"`, cpu, []string{"%"}},
+		{"percent via int", `string(int(result)) + "%"`, cpu, []string{"%"}},
+		{"humanized bytes", `humanizeBytes(result)`, mem, []string{"GB"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			rg, err := resolveGraph(config.Graph{ID: "g", Query: "q", ValueExpr: tc.valueExpr}, config.Defaults{}, env)
+			require.NoError(t, err)
+			svg, err := renderChart(makeMatrix(tc.data), rg.defaults)
+			require.NoError(t, err)
+			for _, w := range tc.want {
+				assert.Contains(t, string(svg), w)
+			}
+			assert.NotRegexp(t, `>\d+\.\d{3,}`, string(svg),
+				"y-axis labels should be round, not full-precision floats")
+		})
+	}
 }
 
 func TestRenderChart_PNG(t *testing.T) {

--- a/internal/kromgo/chart_test.go
+++ b/internal/kromgo/chart_test.go
@@ -64,6 +64,21 @@ func TestRenderChart_ValueFormatter(t *testing.T) {
 	assert.NotContains(t, string(plain), "pods")
 }
 
+func TestRenderChart_NiceYAxisTicks(t *testing.T) {
+	t.Parallel()
+	// Over a non-round data range (e.g. [25.3, 46.94]) the y-axis ticks must still be
+	// round numbers, not an even division like 25/29.39/33.78. Otherwise a
+	// full-precision valueExpr such as `string(result)` prints labels like "46.9405".
+	// A %g formatter (shortest float repr, like string()/humanizeFloat) makes any
+	// non-round tick visible as a long-decimal label.
+	full := func(f float64) string { return fmt.Sprintf("%g", f) }
+	svg, err := renderChart(makeMatrix([][]float64{{25.3, 46.94, 33.1, 41.5, 28.4, 44.0}}),
+		chartParams{width: 600, height: 200, format: formatSVG, valueFormatter: full})
+	require.NoError(t, err)
+	assert.NotRegexp(t, `>\d+\.\d{3,}<`, string(svg),
+		"y-axis ticks should be round, not full-precision floats like 46.9405")
+}
+
 func TestRenderChart_PNG(t *testing.T) {
 	t.Parallel()
 	png, err := renderChart(makeMatrix([][]float64{{10, 25, 15, 40, 30}}),


### PR DESCRIPTION
## What

Sets `PreferNiceIntervals` on graph y-axes so tick values are round numbers.

## The bug

A graph `valueExpr` like `string(result) + "%"` rendered labels like `46.9405%`. It wasn't the expression — it was being applied correctly. The chart library computes y-axis ticks by dividing the data range into equal parts, so for a range like `[25, 46.94]` the *tick values themselves* are arbitrary floats (`29.388…`, `33.776…`), and `string()` faithfully prints them at full precision.

It's a latent issue in all graphs (the default 2-decimal formatter showed `46.94`, `42.55`… too); `valueExpr`'s full precision just made it glaring.

## Before / after

Same data (`[25, 46.94]`), same `valueExpr: string(result) + "%"`:

| before | after |
| --- | --- |
| `46.9405% 42.5524% 38.1643% 33.7762% 29.3881% 25%` | `50% 45% 40% 35% 30% 25%` |

The default (no `valueExpr`) graph improves the same way: `46.94 42.55 …` → `50 45 40 35 30 25`.

## Fix

One line in `renderChart`: ask the y-axis for round intervals (`PreferNiceIntervals: true`), then layer the optional `valueExpr` formatter on top. No config knob — round axis ticks are the right default for metric graphs.

## Test

`TestRenderChart_NiceYAxisTicks` renders over a deliberately non-round range with a full-precision (`%g`) formatter and asserts no y-axis label carries 3+ decimals. Verified it **fails** without this fix (labels like `44.73314285714286`) and passes with it. Full suite + lint green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
