### PR TITLE
feat(graph): optional area fill (fill: true)

### DIFF
--- a/README.md
+++ b/README.md
@@ -320,6 +320,7 @@ opt-in to expose range data for that query — there is no separate enable flag.
 | `width`       | no       | Image width in px (overrides `defaults.graph.width`)                                 |
 | `height`      | no       | Image height in px (overrides `defaults.graph.height`)                               |
 | `legend`      | no       | Show the series legend (overrides `defaults.graph.legend`)                           |
+| `fill`        | no       | Fill a translucent area beneath the line(s) (overrides `defaults.graph.fill`)        |
 | `theme`       | no       | Color theme (overrides `defaults.graph.theme`) — see [Themes](#themes-and-fonts)     |
 | `font`        | no       | Text font (overrides `defaults.graph.font`) — see [Themes](#themes-and-fonts)        |
 | `valueExpr`   | no       | CEL expression formatting the y-axis labels (overrides `defaults.graph.valueExpr`)   |
@@ -359,10 +360,10 @@ The time window is chosen by these query parameters:
 | `end`     | now        | Window end — Unix timestamp or RFC3339                                   |
 | `step`    | window/100 | Resolution between points (min `1m`); supports `s/m/h/d/y` units         |
 
-The rendering fields `width`, `height`, `legend`, and `theme`, plus the output `format` (`svg`/`png`),
-may also be overridden per request via query parameters, e.g.
-`/graphs/node_cpu_usage?theme=dracula&format=png&width=800&last=24h`. (`font` is config-only — it's
-resolved once at startup.)
+The rendering fields `width`, `height`, `legend`, `fill`, and `theme`, plus the output `format`
+(`svg`/`png`), may also be overridden per request via query parameters, e.g.
+`/graphs/node_cpu_usage?theme=dracula&fill=true&format=png&width=800&last=24h`. (`font` and
+`valueExpr` are config-only — they're resolved/compiled once at startup.)
 
 #### Themes and fonts
 

--- a/charts/kromgo/values.yaml
+++ b/charts/kromgo/values.yaml
@@ -57,6 +57,7 @@ config:
   #     style: flat
   #   graph:
   #     theme: dark
+  #     fill: true # translucent area beneath every graph's line
   #     valueExpr: string(int(result)) # integer y-axis labels for every graph
 
   # Instant-value endpoints served at /badges/{id}.
@@ -74,6 +75,7 @@ config:
   #     title: CPU %
   #     query: (time() % 1800) / 18
   #     theme: dark
+  #     fill: true # translucent area beneath the line
   #   - id: pods
   #     title: Running Pods
   #     query: sum(kube_pod_status_phase{phase="Running"})

--- a/config.schema.json
+++ b/config.schema.json
@@ -129,6 +129,9 @@
         "legend": {
           "type": "boolean"
         },
+        "fill": {
+          "type": "boolean"
+        },
         "theme": {
           "type": "string"
         },
@@ -158,6 +161,9 @@
           "type": "integer"
         },
         "legend": {
+          "type": "boolean"
+        },
+        "fill": {
           "type": "boolean"
         },
         "theme": {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -85,6 +85,8 @@ type GraphDefaults struct {
 	Height int `yaml:"height,omitempty" json:"height,omitempty"`
 	// Legend toggles the series legend (defaults to true).
 	Legend *bool `yaml:"legend,omitempty" json:"legend,omitempty"`
+	// Fill draws a translucent area beneath graph lines (defaults to false).
+	Fill *bool `yaml:"fill,omitempty" json:"fill,omitempty"`
 	// Theme selects the color theme (e.g. "dark", "grafana", "catppuccin-mocha", "dracula").
 	Theme string `yaml:"theme,omitempty" json:"theme,omitempty"`
 	// Font selects the text font: dejavu-sans (default), dejavu-sans-bold, comic-neue, or comic-neue-bold.
@@ -142,6 +144,8 @@ type Graph struct {
 	Height int `yaml:"height,omitempty" json:"height,omitempty"`
 	// Legend overrides defaults.graph.legend for this graph.
 	Legend *bool `yaml:"legend,omitempty" json:"legend,omitempty"`
+	// Fill draws a translucent area beneath the line, overriding defaults.graph.fill.
+	Fill *bool `yaml:"fill,omitempty" json:"fill,omitempty"`
 	// Theme overrides defaults.graph.theme for this graph.
 	Theme string `yaml:"theme,omitempty" json:"theme,omitempty"`
 	// Font overrides defaults.graph.font for this graph.

--- a/internal/kromgo/chart.go
+++ b/internal/kromgo/chart.go
@@ -19,6 +19,9 @@ import (
 const (
 	maxChartDimension = 2048
 	formatPNG         = "png"
+	// fillOpacity is the alpha (0-255) for the area fill — translucent so overlapping
+	// per-series fills stay legible (the library's default is a heavier 200).
+	fillOpacity = 90
 )
 
 // chartParams holds the resolved sparkline rendering parameters. The graph's
@@ -31,6 +34,7 @@ type chartParams struct {
 	title  string         // chart title, rendered top-left
 	font   *truetype.Font // nil uses the chart library's default font
 	format string         // "svg" (default) or "png"
+	fill   bool           // draw a translucent area beneath the line(s)
 	// valueFormatter renders y-axis tick values to strings (from the graph's
 	// valueExpr). nil uses the chart library's default numeric formatting.
 	valueFormatter func(float64) string
@@ -55,6 +59,12 @@ func (p chartParams) withOverrides(r *http.Request) chartParams {
 		p.legend = false
 	case "true":
 		p.legend = true
+	}
+	switch q.Get("fill") {
+	case "false":
+		p.fill = false
+	case "true":
+		p.fill = true
 	}
 	if s := q.Get("theme"); s != "" {
 		p.theme = s // unknown names fall back to the default in chartTheme
@@ -137,6 +147,13 @@ func renderChart(matrix model.Matrix, p chartParams) ([]byte, error) {
 	} else {
 		hide := false
 		opt.Legend.Show = &hide
+	}
+	// Fill the area beneath the line(s). The library's default fill alpha (200/255) is
+	// heavy when kromgo's per-series lines overlap, so use a lighter, translucent value.
+	if p.fill {
+		fill := true
+		opt.FillArea = &fill
+		opt.FillOpacity = fillOpacity
 	}
 	// Ask the chart library for round y-axis tick values (e.g. 25/30/35/40/45 rather
 	// than dividing the range evenly into 25/29.39/33.78/…). Without this the ticks

--- a/internal/kromgo/chart_test.go
+++ b/internal/kromgo/chart_test.go
@@ -119,6 +119,21 @@ func TestRenderGraph_ConfigTable(t *testing.T) {
 	}
 }
 
+func TestRenderChart_FillArea(t *testing.T) {
+	t.Parallel()
+	data := makeMatrix([][]float64{{10, 25, 15, 40, 30}})
+
+	// fill draws a translucent area (rgba) beneath the line.
+	filled, err := renderChart(data, chartParams{width: 400, height: 150, format: formatSVG, fill: true})
+	require.NoError(t, err)
+	assert.Contains(t, string(filled), "fill:rgba", "fill should draw a translucent area")
+
+	// Without fill, only the line stroke is drawn — no area fill.
+	plain, err := renderChart(data, chartParams{width: 400, height: 150, format: formatSVG})
+	require.NoError(t, err)
+	assert.NotContains(t, string(plain), "fill:rgba", "no area fill when fill is off")
+}
+
 func TestRenderChart_PNG(t *testing.T) {
 	t.Parallel()
 	png, err := renderChart(makeMatrix([][]float64{{10, 25, 15, 40, 30}}),
@@ -169,12 +184,13 @@ func TestChartParams_WithOverrides(t *testing.T) {
 	base := chartParams{width: 300, height: 80, legend: true, theme: "dark", format: formatSVG}
 
 	req := httptest.NewRequest(http.MethodGet,
-		"/?width=500&height=250&legend=false&theme=dracula&format=png", nil)
+		"/?width=500&height=250&legend=false&fill=true&theme=dracula&format=png", nil)
 	got := base.withOverrides(req)
 
 	assert.Equal(t, 500, got.width)
 	assert.Equal(t, 250, got.height)
 	assert.False(t, got.legend)
+	assert.True(t, got.fill)
 	assert.Equal(t, "dracula", got.theme)
 	assert.Equal(t, formatPNG, got.format)
 	assert.Equal(t, "image/png", got.contentType())

--- a/internal/kromgo/graph_query_test.go
+++ b/internal/kromgo/graph_query_test.go
@@ -160,6 +160,7 @@ func TestResolveGraph_DefaultParams(t *testing.T) {
 	assert.Equal(t, defaultGraphWidth, rg.defaults.width)
 	assert.Equal(t, defaultGraphHeight, rg.defaults.height)
 	assert.True(t, rg.defaults.legend, "legend defaults to true")
+	assert.False(t, rg.defaults.fill, "fill defaults to false")
 	assert.Nil(t, rg.defaults.valueFormatter, "no valueExpr ⇒ default numeric formatting")
 }
 

--- a/internal/kromgo/metric.go
+++ b/internal/kromgo/metric.go
@@ -104,6 +104,7 @@ func resolveGraph(g config.Graph, def config.Defaults, env *cel.Env) (*resolvedG
 			width:  cmp.Or(g.Width, def.Graph.Width, defaultGraphWidth),
 			height: cmp.Or(g.Height, def.Graph.Height, defaultGraphHeight),
 			legend: firstSet(true, g.Legend, def.Graph.Legend),
+			fill:   firstSet(false, g.Fill, def.Graph.Fill),
 			theme:  theme,
 			title:  displayTitle(g.Title, g.ID),
 			font:   font,


### PR DESCRIPTION
## What

Adds an opt-in `fill` for graphs that draws a translucent area beneath the line(s):

```yaml
graphs:
  - id: cpu
    title: CPU Usage
    query: ...
    fill: true
```

Settable per-graph, as `defaults.graph.fill`, or per-request via `?fill=true`.

## Why

At the small sizes these graphs are usually embedded (a README, a dashboard tile), a thin stroke is hard to read. A filled area is the familiar, legible dashboard look. First of the `go-analyze/charts` UI features we discussed.

## Notes

- **Off by default** — purely additive.
- **Opacity:** the library defaults area fill to `200/255` (~78%), which is heavy when kromgo's per-series lines overlap. This uses a lighter `90/255` (~35%) so multiple series stay readable (verified by rendering single- and two-series graphs).

## Tests / docs

- `TestRenderChart_FillArea` (asserts the translucent `fill:rgba` area is drawn with `fill: true`, absent without); `fill` added to the `withOverrides` and `resolveGraph` default tests.
- `config.schema.json` regenerated (`fill: boolean` on graph + graphDefaults); README graph table + override note and `values.yaml` examples updated. Full suite + lint + helm lint green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
