### PR TITLE
feat(graph): y-axis min/max + reference mark lines

### DIFF
--- a/README.md
+++ b/README.md
@@ -311,20 +311,22 @@ opt-in to expose range data for that query — there is no separate enable flag.
 [go-analyze/charts](https://github.com/go-analyze/charts) as **SVG** (default) or **PNG**
 (`?format=png`).
 
-| Field         | Required | Description                                                                          |
-| ------------- | -------- | ------------------------------------------------------------------------------------ |
-| `id`          | yes      | URL path segment — `cpu` → `GET /graphs/cpu`                                         |
-| `query`       | yes      | PromQL expression run as a range query                                               |
-| `title`       | no       | Display label (defaults to `id`)                                                     |
-| `maxDuration` | no       | Cap on the requested window (overrides `defaults.graph.maxDuration`)                 |
-| `width`       | no       | Image width in px (overrides `defaults.graph.width`)                                 |
-| `height`      | no       | Image height in px (overrides `defaults.graph.height`)                               |
-| `legend`      | no       | Show the series legend (overrides `defaults.graph.legend`)                           |
-| `fill`        | no       | Fill a translucent area beneath the line(s) (overrides `defaults.graph.fill`)        |
-| `theme`       | no       | Color theme (overrides `defaults.graph.theme`) — see [Themes](#themes-and-fonts)     |
-| `font`        | no       | Text font (overrides `defaults.graph.font`) — see [Themes](#themes-and-fonts)        |
-| `valueExpr`   | no       | CEL expression formatting the y-axis labels (overrides `defaults.graph.valueExpr`)   |
-| `gallery`     | no       | Per-graph gallery settings, e.g. `gallery: {hidden: true}` — see [Gallery](#gallery) |
+| Field         | Required | Description                                                                           |
+| ------------- | -------- | ------------------------------------------------------------------------------------- |
+| `id`          | yes      | URL path segment — `cpu` → `GET /graphs/cpu`                                          |
+| `query`       | yes      | PromQL expression run as a range query                                                |
+| `title`       | no       | Display label (defaults to `id`)                                                      |
+| `maxDuration` | no       | Cap on the requested window (overrides `defaults.graph.maxDuration`)                  |
+| `width`       | no       | Image width in px (overrides `defaults.graph.width`)                                  |
+| `height`      | no       | Image height in px (overrides `defaults.graph.height`)                                |
+| `legend`      | no       | Show the series legend (overrides `defaults.graph.legend`)                            |
+| `fill`        | no       | Fill a translucent area beneath the line(s) (overrides `defaults.graph.fill`)         |
+| `theme`       | no       | Color theme (overrides `defaults.graph.theme`) — see [Themes](#themes-and-fonts)      |
+| `font`        | no       | Text font (overrides `defaults.graph.font`) — see [Themes](#themes-and-fonts)         |
+| `valueExpr`   | no       | CEL expression formatting the y-axis labels (overrides `defaults.graph.valueExpr`)    |
+| `yMin`/`yMax` | no       | Pin the y-axis range instead of auto-fitting (overrides `defaults.graph.yMin`/`yMax`) |
+| `markLine`    | no       | Dashed reference lines: any of `average`, `min`, `max`, `median` (first series only)  |
+| `gallery`     | no       | Per-graph gallery settings, e.g. `gallery: {hidden: true}` — see [Gallery](#gallery)  |
 
 ```yaml
 graphs:
@@ -351,6 +353,22 @@ graphs:
       valueExpr: string(int(result)) + " pods" # integer ticks; drop the suffix for bare integers
 ```
 
+For axis context, pin the range with `yMin`/`yMax` (e.g. `yMin: 0`, `yMax: 100` for a percentage)
+rather than letting it auto-fit, and add dashed reference lines with `markLine` (`average`, `min`,
+`max`, or `median`). Mark lines are computed by the chart library — there's no static-threshold line,
+and they render for the first series only:
+
+```yaml
+graphs:
+    - id: cluster_cpu_graph
+      title: CPU Usage
+      query: avg(cluster:node_cpu:ratio_rate5m) * 100
+      valueExpr: string(int(result)) + "%"
+      yMin: 0
+      yMax: 100
+      markLine: [average]
+```
+
 The time window is chosen by these query parameters:
 
 | Parameter | Default    | Description                                                              |
@@ -360,10 +378,10 @@ The time window is chosen by these query parameters:
 | `end`     | now        | Window end — Unix timestamp or RFC3339                                   |
 | `step`    | window/100 | Resolution between points (min `1m`); supports `s/m/h/d/y` units         |
 
-The rendering fields `width`, `height`, `legend`, `fill`, and `theme`, plus the output `format`
-(`svg`/`png`), may also be overridden per request via query parameters, e.g.
-`/graphs/node_cpu_usage?theme=dracula&fill=true&format=png&width=800&last=24h`. (`font` and
-`valueExpr` are config-only — they're resolved/compiled once at startup.)
+The rendering fields `width`, `height`, `legend`, `fill`, `yMin`/`yMax`, and `theme`, plus the output
+`format` (`svg`/`png`), may also be overridden per request via query parameters, e.g.
+`/graphs/node_cpu_usage?theme=dracula&fill=true&ymax=100&format=png&last=24h`. (`font`, `valueExpr`,
+and `markLine` are config-only — resolved/compiled once at startup.)
 
 #### Themes and fonts
 

--- a/charts/kromgo/values.yaml
+++ b/charts/kromgo/values.yaml
@@ -76,6 +76,9 @@ config:
   #     query: (time() % 1800) / 18
   #     theme: dark
   #     fill: true # translucent area beneath the line
+  #     yMin: 0 # pin the y-axis range (vs auto-fitting); e.g. 0–100 for a percentage
+  #     yMax: 100
+  #     markLine: [average] # dashed reference line(s): average / min / max / median (first series only)
   #   - id: pods
   #     title: Running Pods
   #     query: sum(kube_pod_status_phase{phase="Running"})

--- a/config.schema.json
+++ b/config.schema.json
@@ -141,6 +141,18 @@
         "valueExpr": {
           "type": "string"
         },
+        "yMin": {
+          "type": "number"
+        },
+        "yMax": {
+          "type": "number"
+        },
+        "markLine": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
         "gallery": {
           "$ref": "#/$defs/GallerySettings"
         }
@@ -174,6 +186,18 @@
         },
         "valueExpr": {
           "type": "string"
+        },
+        "yMin": {
+          "type": "number"
+        },
+        "yMax": {
+          "type": "number"
+        },
+        "markLine": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
         },
         "gallery": {
           "$ref": "#/$defs/GallerySettings"

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -94,6 +94,11 @@ type GraphDefaults struct {
 	// ValueExpr is the default y-axis label formatter (a CEL expression over `result`)
 	// for graphs — see Graph.ValueExpr.
 	ValueExpr string `yaml:"valueExpr,omitempty" json:"valueExpr,omitempty"`
+	// YMin and YMax pin the default y-axis range for graphs — see Graph.YMin/YMax.
+	YMin *float64 `yaml:"yMin,omitempty" json:"yMin,omitempty"`
+	YMax *float64 `yaml:"yMax,omitempty" json:"yMax,omitempty"`
+	// MarkLine is the default set of mark-line types for graphs — see Graph.MarkLine.
+	MarkLine []string `yaml:"markLine,omitempty" json:"markLine,omitempty"`
 	// Gallery is the default gallery visibility for graphs.
 	Gallery GallerySettings `yaml:"gallery,omitempty" json:"gallery,omitempty"`
 }
@@ -157,6 +162,15 @@ type Graph struct {
 	// (an axis tick has no labels). Empty uses the chart's default numeric formatting.
 	// Overrides defaults.graph.valueExpr.
 	ValueExpr string `yaml:"valueExpr,omitempty" json:"valueExpr,omitempty"`
+	// YMin and YMax pin the y-axis range (e.g. 0 and 100 for a percentage) instead of
+	// auto-fitting to the data. Either may be set alone. Override defaults.graph.yMin/yMax.
+	YMin *float64 `yaml:"yMin,omitempty" json:"yMin,omitempty"`
+	YMax *float64 `yaml:"yMax,omitempty" json:"yMax,omitempty"`
+	// MarkLine draws dashed reference lines at computed values: any of "average", "min",
+	// "max", "median". The chart library renders them for the first series only, and
+	// only these dynamic types are supported (no static threshold). Overrides
+	// defaults.graph.markLine.
+	MarkLine []string `yaml:"markLine,omitempty" json:"markLine,omitempty"`
 	// Gallery holds this graph's gallery settings (e.g. hidden), overriding defaults.graph.gallery.
 	Gallery GallerySettings `yaml:"gallery,omitempty" json:"gallery,omitempty"`
 }

--- a/internal/kromgo/chart.go
+++ b/internal/kromgo/chart.go
@@ -35,6 +35,11 @@ type chartParams struct {
 	font   *truetype.Font // nil uses the chart library's default font
 	format string         // "svg" (default) or "png"
 	fill   bool           // draw a translucent area beneath the line(s)
+	yMin   *float64       // pin the y-axis minimum; nil auto-fits
+	yMax   *float64       // pin the y-axis maximum; nil auto-fits
+	// markLines lists dashed reference lines to draw (average/min/max/median),
+	// validated at resolve time. Rendered on the first series only.
+	markLines []string
 	// valueFormatter renders y-axis tick values to strings (from the graph's
 	// valueExpr). nil uses the chart library's default numeric formatting.
 	valueFormatter func(float64) string
@@ -65,6 +70,16 @@ func (p chartParams) withOverrides(r *http.Request) chartParams {
 		p.fill = false
 	case "true":
 		p.fill = true
+	}
+	if s := q.Get("ymin"); s != "" {
+		if v, err := strconv.ParseFloat(s, 64); err == nil {
+			p.yMin = &v
+		}
+	}
+	if s := q.Get("ymax"); s != "" {
+		if v, err := strconv.ParseFloat(s, 64); err == nil {
+			p.yMax = &v
+		}
 	}
 	if s := q.Get("theme"); s != "" {
 		p.theme = s // unknown names fall back to the default in chartTheme
@@ -161,11 +176,20 @@ func renderChart(matrix model.Matrix, p chartParams) ([]byte, error) {
 	// full precision ("46.9405%"). A graph's valueExpr (if any) then formats those
 	// values — integers or humanized units in place of the default 2-decimal numbers.
 	niceIntervals := true
-	yAxis := charts.YAxisOption{PreferNiceIntervals: &niceIntervals}
+	yAxis := charts.YAxisOption{PreferNiceIntervals: &niceIntervals, Min: p.yMin, Max: p.yMax}
 	if p.valueFormatter != nil {
 		yAxis.ValueFormatter = p.valueFormatter
 	}
 	opt.YAxis = []charts.YAxisOption{yAxis}
+
+	// Dashed reference lines (average/min/max/median). The chart library renders mark
+	// lines for the first series only; reuse the y-axis formatter so the mark values
+	// match the axis labels.
+	if len(p.markLines) > 0 && len(opt.SeriesList) > 0 {
+		markLine := charts.NewMarkLine(p.markLines...)
+		markLine.ValueFormatter = p.valueFormatter
+		opt.SeriesList[0].MarkLine = markLine
+	}
 
 	// Font is set on the painter (the non-deprecated default-font hook). resolveGraphFont
 	// always returns a face (DejaVu Sans by default), so p.font is never nil here.

--- a/internal/kromgo/chart_test.go
+++ b/internal/kromgo/chart_test.go
@@ -134,6 +134,33 @@ func TestRenderChart_FillArea(t *testing.T) {
 	assert.NotContains(t, string(plain), "fill:rgba", "no area fill when fill is off")
 }
 
+func TestRenderChart_YAxisBounds(t *testing.T) {
+	t.Parallel()
+	// Data sits in ~[31, 52]; pinning the axis to 0–100 makes labels appear well
+	// outside the data's own range, proving the bounds took effect.
+	data := makeMatrix([][]float64{{31, 45, 38, 52, 41}})
+	zero, hundred := 0.0, 100.0
+	svg, err := renderChart(data, chartParams{width: 400, height: 150, format: formatSVG, yMin: &zero, yMax: &hundred})
+	require.NoError(t, err)
+	assert.Contains(t, string(svg), ">100</text>", "y-axis max pinned to 100")
+	assert.Contains(t, string(svg), ">0</text>", "y-axis min pinned to 0")
+}
+
+func TestRenderChart_MarkLine(t *testing.T) {
+	t.Parallel()
+	data := makeMatrix([][]float64{{10, 20, 30, 40, 50}})
+
+	// A mark line is drawn as a dashed stroke.
+	marked, err := renderChart(data, chartParams{width: 400, height: 150, format: formatSVG, markLines: []string{"average"}})
+	require.NoError(t, err)
+	assert.Contains(t, string(marked), "stroke-dasharray", "mark line is drawn dashed")
+
+	// Without one, nothing dashed is emitted.
+	plain, err := renderChart(data, chartParams{width: 400, height: 150, format: formatSVG})
+	require.NoError(t, err)
+	assert.NotContains(t, string(plain), "stroke-dasharray", "no mark line without markLines")
+}
+
 func TestRenderChart_PNG(t *testing.T) {
 	t.Parallel()
 	png, err := renderChart(makeMatrix([][]float64{{10, 25, 15, 40, 30}}),
@@ -184,13 +211,17 @@ func TestChartParams_WithOverrides(t *testing.T) {
 	base := chartParams{width: 300, height: 80, legend: true, theme: "dark", format: formatSVG}
 
 	req := httptest.NewRequest(http.MethodGet,
-		"/?width=500&height=250&legend=false&fill=true&theme=dracula&format=png", nil)
+		"/?width=500&height=250&legend=false&fill=true&ymin=0&ymax=100&theme=dracula&format=png", nil)
 	got := base.withOverrides(req)
 
 	assert.Equal(t, 500, got.width)
 	assert.Equal(t, 250, got.height)
 	assert.False(t, got.legend)
 	assert.True(t, got.fill)
+	require.NotNil(t, got.yMin)
+	assert.Equal(t, 0.0, *got.yMin)
+	require.NotNil(t, got.yMax)
+	assert.Equal(t, 100.0, *got.yMax)
 	assert.Equal(t, "dracula", got.theme)
 	assert.Equal(t, formatPNG, got.format)
 	assert.Equal(t, "image/png", got.contentType())

--- a/internal/kromgo/graph_query_test.go
+++ b/internal/kromgo/graph_query_test.go
@@ -161,7 +161,31 @@ func TestResolveGraph_DefaultParams(t *testing.T) {
 	assert.Equal(t, defaultGraphHeight, rg.defaults.height)
 	assert.True(t, rg.defaults.legend, "legend defaults to true")
 	assert.False(t, rg.defaults.fill, "fill defaults to false")
+	assert.Nil(t, rg.defaults.yMin, "y-axis auto-fits by default")
+	assert.Nil(t, rg.defaults.yMax, "y-axis auto-fits by default")
+	assert.Empty(t, rg.defaults.markLines, "no mark lines by default")
 	assert.Nil(t, rg.defaults.valueFormatter, "no valueExpr ⇒ default numeric formatting")
+}
+
+func TestResolveGraph_MarkLine(t *testing.T) {
+	t.Parallel()
+	env, err := newCELEnv()
+	require.NoError(t, err)
+
+	// Valid types resolve onto the params.
+	rg, err := resolveGraph(config.Graph{ID: "g", Query: "q", MarkLine: []string{"average", "max"}}, config.Defaults{}, env)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"average", "max"}, rg.defaults.markLines)
+
+	// defaults.graph.markLine applies when the graph doesn't set its own.
+	rg, err = resolveGraph(config.Graph{ID: "g", Query: "q"}, config.Defaults{Graph: config.GraphDefaults{MarkLine: []string{"average"}}}, env)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"average"}, rg.defaults.markLines)
+
+	// An unknown mark type fails at resolve (startup), not on a request.
+	_, err = resolveGraph(config.Graph{ID: "g", Query: "q", MarkLine: []string{"p99"}}, config.Defaults{}, env)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "markLine")
 }
 
 func TestResolveGraph_ValueExpr(t *testing.T) {

--- a/internal/kromgo/metric.go
+++ b/internal/kromgo/metric.go
@@ -85,6 +85,10 @@ func resolveBadge(b config.Badge, def config.Defaults, env *cel.Env) (*resolvedB
 	return rb, nil
 }
 
+// validMarkLine is the set of mark-line types the chart library supports — dynamic
+// values computed from the series, with no static-threshold option.
+var validMarkLine = map[string]bool{"average": true, "min": true, "max": true, "median": true}
+
 // resolveGraph precomputes a graph's cache TTL, window cap, and default parameters.
 func resolveGraph(g config.Graph, def config.Defaults, env *cel.Env) (*resolvedGraph, error) {
 	theme := cmp.Or(g.Theme, def.Graph.Theme)
@@ -97,18 +101,31 @@ func resolveGraph(g config.Graph, def config.Defaults, env *cel.Env) (*resolvedG
 		return nil, fmt.Errorf("graph %q font: %w", g.ID, err)
 	}
 
+	markLines := g.MarkLine
+	if markLines == nil {
+		markLines = def.Graph.MarkLine
+	}
+	for _, m := range markLines {
+		if !validMarkLine[m] {
+			return nil, fmt.Errorf("graph %q markLine: unknown type %q (want average, min, max, or median)", g.ID, m)
+		}
+	}
+
 	rg := &resolvedGraph{
 		Graph:       g,
 		maxDuration: defaultGraphMaxDuration,
 		defaults: chartParams{
-			width:  cmp.Or(g.Width, def.Graph.Width, defaultGraphWidth),
-			height: cmp.Or(g.Height, def.Graph.Height, defaultGraphHeight),
-			legend: firstSet(true, g.Legend, def.Graph.Legend),
-			fill:   firstSet(false, g.Fill, def.Graph.Fill),
-			theme:  theme,
-			title:  displayTitle(g.Title, g.ID),
-			font:   font,
-			format: formatSVG,
+			width:     cmp.Or(g.Width, def.Graph.Width, defaultGraphWidth),
+			height:    cmp.Or(g.Height, def.Graph.Height, defaultGraphHeight),
+			legend:    firstSet(true, g.Legend, def.Graph.Legend),
+			fill:      firstSet(false, g.Fill, def.Graph.Fill),
+			yMin:      cmp.Or(g.YMin, def.Graph.YMin),
+			yMax:      cmp.Or(g.YMax, def.Graph.YMax),
+			markLines: markLines,
+			theme:     theme,
+			title:     displayTitle(g.Title, g.ID),
+			font:      font,
+			format:    formatSVG,
 		},
 	}
 	if maxStr := cmp.Or(g.MaxDuration, def.Graph.MaxDuration); maxStr != "" {


### PR DESCRIPTION
## What

Two graph options, both per-graph and as `defaults.graph`:

```yaml
graphs:
  - id: cpu
    query: avg(cluster:node_cpu:ratio_rate5m) * 100
    valueExpr: string(int(result)) + "%"
    yMin: 0
    yMax: 100
    markLine: [average]
```

- **`yMin` / `yMax`** — pin the y-axis range instead of auto-fitting. Also overridable per request (`?ymin=0&ymax=100`).
- **`markLine`** — dashed reference lines at `average` / `min` / `max` / `median`, with labels formatted by the graph's `valueExpr` (so they match the axis).

## Why

Pinning the range gives **context** — the auto-range zooms to the data, so a stable 40–46% CPU series fills the whole height and looks dramatic; `yMin: 0, yMax: 100` shows it sitting calmly at ~40% of a full scale. Mark lines add an at-a-glance "what's normal" cue.

## ⚠️ Mark-line caveats (please sanity-check)

The underlying `go-analyze/charts` mark-line API turned out more limited than I pitched:

- **No static threshold.** Only dynamic types (`average`/`min`/`max`/`median`) are supported — there's no "draw a line at y=80". A static threshold would need a hack (a constant extra series), which I did **not** do.
- **First series only.** The library renders mark lines for the first series, so on a multi-series graph (e.g. `by (cluster_id)`) the line reflects only the first cluster. Fine for single-series graphs (`sum(...)`, totals), weaker for multi-series.

`yMin`/`yMax` have no such caveats. If the mark line isn't worth it given these limits, say so and I'll drop it from this PR — the y-axis bounds stand on their own.

## Tests / docs

`TestRenderChart_YAxisBounds` (labels appear outside the data range), `TestRenderChart_MarkLine` (dashed stroke present/absent), `TestResolveGraph_MarkLine` (valid/default/unknown-type-errors), plus `yMin`/`yMax` in the override + default tests. `config.schema.json` regenerated; README graph table/override note and `values.yaml` examples updated. Full suite, lint, helm lint green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
