### PR TITLE
ci: regenerate chart docs in renovate postUpgrade tasks

### DIFF
--- a/.renovaterc.json5
+++ b/.renovaterc.json5
@@ -2,6 +2,18 @@
   $schema: "https://docs.renovatebot.com/renovate-schema.json",
   extends: ["local>home-operations/renovate-config"],
   postUpdateOptions: ["gomodTidy", "gomodUpdateImportPaths"],
+  // Regenerate the chart's committed docs after an upgrade so a value bump
+  // doesn't leave README.md / values.schema.json stale and fail generate-check.
+  // Runs the helm-docs + helm-schema binaries shipped in the Renovate container
+  // (mirrors the chart-doc half of `mise run generate`).
+  postUpgradeTasks: {
+    commands: [
+      "helm-docs --chart-search-root=charts --log-level=warn",
+      "helm-schema --chart-search-root charts/kromgo --skip-auto-generation required,additionalProperties --append-newline",
+    ],
+    fileFilters: ["charts/kromgo/README.md", "charts/kromgo/values.schema.json"],
+    executionMode: "branch",
+  },
   packageRules: [
     {
       description: "Go Toolchain Group",


### PR DESCRIPTION
Adds a Renovate `postUpgradeTask` that regenerates the chart's committed `README.md` + `values.schema.json` after an upgrade, so a Renovate bump to a charted value can't leave them stale and fail the `generate-check` (Lint) gate.

It runs `helm-docs` + `helm-schema` directly — the binaries now ship in the Renovate container ([home-operations/.github#14](https://github.com/home-operations/.github/pull/14)) and the commands are allowlisted ([home-operations/.github#15](https://github.com/home-operations/.github/pull/15)) — and commits the result via `fileFilters`. The commands mirror the chart-doc half of `mise run generate` (the Go config-schema half isn't affected by dependency bumps, so it's intentionally skipped).

> Depends on .github#14 (merged) + #15 (allowlist) to actually execute.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
