### PR TITLE
fix(chart): pin the helm-test image as tag@digest so renovate updates both

### DIFF
--- a/charts/kromgo/README.md
+++ b/charts/kromgo/README.md
@@ -103,10 +103,9 @@ Kubernetes: `>=1.25.0-0`
 | serviceAccount.automount | bool | `false` | Automount the ServiceAccount API token (off by default: kromgo talks to Prometheus, not the cluster API). |
 | serviceAccount.create | bool | `true` | Create a ServiceAccount. |
 | serviceAccount.name | string | `""` | ServiceAccount name; generated from the release name if empty. |
-| tests.image.digest | string | `"sha256:9532d8c39891ca2ecde4d30d7710e01fb739c87a8b9299685c63704296b16028"` | `helm test` image digest (sha256:…); pins immutably and wins over the tag when set. |
 | tests.image.pullPolicy | string | `"IfNotPresent"` | `helm test` image pull policy. |
 | tests.image.repository | string | `"mirror.gcr.io/busybox"` | `helm test` pod image; needs a shell with wget (kromgo's own image is from scratch). |
-| tests.image.tag | string | `"1.37.0"` | `helm test` image tag. |
+| tests.image.tag | string | `"1.37.0@sha256:9532d8c39891ca2ecde4d30d7710e01fb739c87a8b9299685c63704296b16028"` | `helm test` image, pinned as `tag@sha256:digest` so Renovate bumps the tag and its digest together. |
 | tolerations | list | `[]` | Tolerations for pod scheduling. |
 | volumeMounts | list | `[]` | Additional volume mounts on the container. |
 | volumes | list | `[]` | Additional volumes on the Deployment. |

--- a/charts/kromgo/templates/_helpers.tpl
+++ b/charts/kromgo/templates/_helpers.tpl
@@ -74,15 +74,12 @@ repository:tag, with tag defaulting to the chart appVersion.
 
 {{/*
 Image for the `helm test` connection pod (kromgo's own image is built FROM
-scratch, so the test uses a small image with a shell). A digest wins over the tag.
+scratch, so the test uses a small image with a shell). The tag is pinned as
+`version@sha256:digest`, so Renovate updates the version and digest together.
 */}}
 {{- define "kromgo.testImage" -}}
 {{- $img := .Values.tests.image -}}
-{{- if $img.digest -}}
-{{- printf "%s@%s" $img.repository $img.digest -}}
-{{- else -}}
 {{- printf "%s:%s" $img.repository $img.tag -}}
-{{- end -}}
 {{- end }}
 
 {{/*

--- a/charts/kromgo/tests/test-connection_test.yaml
+++ b/charts/kromgo/tests/test-connection_test.yaml
@@ -2,7 +2,7 @@ suite: test-connection
 templates:
   - tests/test-connection.tpl
 tests:
-  - it: is a hardened helm test Pod that probes /readyz with the pinned busybox
+  - it: is a hardened helm test Pod that probes /readyz with the tag+digest-pinned busybox
     asserts:
       - isKind:
           of: Pod
@@ -11,7 +11,7 @@ tests:
           value: test
       - matchRegex:
           path: spec.containers[0].image
-          pattern: busybox@sha256:[0-9a-f]{64}$
+          pattern: busybox:.+@sha256:[0-9a-f]{64}$
       - equal:
           path: spec.securityContext.runAsNonRoot
           value: true

--- a/charts/kromgo/values.schema.json
+++ b/charts/kromgo/values.schema.json
@@ -692,12 +692,6 @@
       "properties": {
         "image": {
           "properties": {
-            "digest": {
-              "default": "sha256:9532d8c39891ca2ecde4d30d7710e01fb739c87a8b9299685c63704296b16028",
-              "description": "`helm test` image digest (sha256:…); pins immutably and wins over the tag when set.",
-              "title": "digest",
-              "type": "string"
-            },
             "pullPolicy": {
               "default": "IfNotPresent",
               "description": "`helm test` image pull policy.",
@@ -711,8 +705,8 @@
               "type": "string"
             },
             "tag": {
-              "default": "1.37.0",
-              "description": "`helm test` image tag.",
+              "default": "1.37.0@sha256:9532d8c39891ca2ecde4d30d7710e01fb739c87a8b9299685c63704296b16028",
+              "description": "`helm test` image, pinned as `tag",
               "title": "tag",
               "type": "string"
             }

--- a/charts/kromgo/values.yaml
+++ b/charts/kromgo/values.yaml
@@ -298,9 +298,7 @@ tests:
   image:
     # -- `helm test` pod image; needs a shell with wget (kromgo's own image is from scratch).
     repository: mirror.gcr.io/busybox
-    # -- `helm test` image tag.
-    tag: "1.37.0"
-    # -- `helm test` image digest (sha256:…); pins immutably and wins over the tag when set.
-    digest: "sha256:9532d8c39891ca2ecde4d30d7710e01fb739c87a8b9299685c63704296b16028"
+    # -- `helm test` image, pinned as `tag@sha256:digest` so Renovate bumps the tag and its digest together.
+    tag: "1.37.0@sha256:9532d8c39891ca2ecde4d30d7710e01fb739c87a8b9299685c63704296b16028"
     # -- `helm test` image pull policy.
     pullPolicy: IfNotPresent


### PR DESCRIPTION
Fixes the issue where Renovate bumps the `helm test` busybox **tag** but not its **digest**, leaving them out of sync (and since the chart made the digest win over the tag, the bump was silently inert — the pod kept running the old image). See home-operations/konflate#63 for the symptom.

## Change

Collapse the test image's separate `tag` + `digest` values into a single pinned reference:

```yaml
tests:
  image:
    repository: mirror.gcr.io/busybox
    tag: "1.37.0@sha256:9532…"   # was: tag + a separate digest field
```

Renovate's `helm-values` manager treats a `version@sha256:…` tag as one docker dependency and updates the version **and** digest together. `kromgo.testImage` is simplified to `repository:tag`, and the unit-test assertion + generated docs are updated to match.

## Verified

- `helm template` renders `mirror.gcr.io/busybox:1.37.0@sha256:…` (valid combined ref).
- `helm unittest` 16/16; `mise run generate` idempotent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
