### PR TITLE
ci: sign the published Helm chart with Cosign

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -76,6 +76,7 @@ jobs:
     runs-on: ubuntu-24.04
     permissions:
       contents: read
+      id-token: write # keyless Cosign signing of the published chart
       packages: write
     env:
       VERSION: ${{ github.event.release.tag_name }}
@@ -119,3 +120,7 @@ jobs:
       - name: Publish Helm chart to GHCR (OCI)
         run: |-
           helm push "kromgo-${VERSION}.tgz" "oci://ghcr.io/${{ github.repository_owner }}/charts"
+
+      - name: Sign the published chart with Cosign
+        run: |-
+          cosign sign --yes "ghcr.io/${{ github.repository_owner }}/charts/kromgo:${VERSION}"

--- a/.mise/config.toml
+++ b/.mise/config.toml
@@ -10,6 +10,7 @@
 go = "1.26.4"
 golangci-lint = "2.12.2"
 helm = "4.2.0"
+cosign = "3.0.6"
 "aqua:dadav/helm-schema" = "0.23.4"
 lefthook = "2.1.9"
 node = "24.16.0"

--- a/.mise/mise.lock
+++ b/.mise/mise.lock
@@ -32,6 +32,45 @@ url = "https://github.com/dadav/helm-schema/releases/download/0.23.4/helm-schema
 checksum = "sha256:261f93081473ae8d465b29320f55282d979af9aa2c0585ad82dbc10db4d89175"
 url = "https://github.com/dadav/helm-schema/releases/download/0.23.4/helm-schema_0.23.4_Windows_x86_64.zip"
 
+[[tools.cosign]]
+version = "3.0.6"
+backend = "aqua:sigstore/cosign"
+
+[tools.cosign."platforms.linux-arm64"]
+checksum = "sha256:bedac92e8c3729864e13d4a17048007cfafa79d5deca993a43a90ffe018ef2b8"
+url = "https://github.com/sigstore/cosign/releases/download/v3.0.6/cosign-linux-arm64"
+provenance = "cosign"
+
+[tools.cosign."platforms.linux-arm64-musl"]
+checksum = "sha256:bedac92e8c3729864e13d4a17048007cfafa79d5deca993a43a90ffe018ef2b8"
+url = "https://github.com/sigstore/cosign/releases/download/v3.0.6/cosign-linux-arm64"
+provenance = "cosign"
+
+[tools.cosign."platforms.linux-x64"]
+checksum = "sha256:c956e5dfcac53d52bcf058360d579472f0c1d2d9b69f55209e256fe7783f4c74"
+url = "https://github.com/sigstore/cosign/releases/download/v3.0.6/cosign-linux-amd64"
+provenance = "cosign"
+
+[tools.cosign."platforms.linux-x64-musl"]
+checksum = "sha256:c956e5dfcac53d52bcf058360d579472f0c1d2d9b69f55209e256fe7783f4c74"
+url = "https://github.com/sigstore/cosign/releases/download/v3.0.6/cosign-linux-amd64"
+provenance = "cosign"
+
+[tools.cosign."platforms.macos-arm64"]
+checksum = "sha256:5fadd012ae6381a6a29ff86a7d39aa873878852f1073fc90b15995961ecfb084"
+url = "https://github.com/sigstore/cosign/releases/download/v3.0.6/cosign-darwin-arm64"
+provenance = "cosign"
+
+[tools.cosign."platforms.macos-x64"]
+checksum = "sha256:4c3e7af8372d3ca3296e62fa56f23fcbb5721cc6ac1827900d398f110d7cd280"
+url = "https://github.com/sigstore/cosign/releases/download/v3.0.6/cosign-darwin-amd64"
+provenance = "cosign"
+
+[tools.cosign."platforms.windows-x64"]
+checksum = "sha256:9b85a88ebff2d9dd30ff4984a6f61f2cedc232dd87d81fa7f2ff3c0ed96c241c"
+url = "https://github.com/sigstore/cosign/releases/download/v3.0.6/cosign-windows-amd64.exe"
+provenance = "cosign"
+
 [[tools.go]]
 version = "1.26.4"
 backend = "core:go"


### PR DESCRIPTION
Cosign-sign the chart OCI artifact after it's pushed to GHCR, matching how [`charts-mirror`](https://github.com/home-operations/charts-mirror) already signs its published charts.

### What
- Add `cosign` (3.0.6, same pin as charts-mirror) as a mise tool — pinned + locked like the rest of the toolchain.
- Grant the `helm` job `id-token: write` so cosign can keyless-sign via OIDC/Fulcio.
- After `helm push`, run `cosign sign --yes ghcr.io/<owner>/charts/kromgo:${VERSION}`.

### Why
The container image is already signed (`sign: true` via `docker/github-builder`), but the **chart** OCI artifact was unsigned. This closes that gap so consumers can `cosign verify` the chart the same way they can the image.

### Verify (after the next release)
```sh
cosign verify ghcr.io/home-operations/charts/kromgo:<version> \
  --certificate-identity-regexp '^https://github.com/home-operations/kromgo/' \
  --certificate-oidc-issuer https://token.actions.githubusercontent.com
```

zizmor clean; `mise lock` generated the cosign entry for all 7 platforms.
