### PR TITLE
ci: path-filter triggers, add concurrency, cache golangci-lint

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -6,9 +6,13 @@ on:
   push:
     branches:
       - main
+    paths-ignore:
+      - "**.md"
   pull_request:
     branches:
       - main
+    paths-ignore:
+      - "**.md"
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -34,7 +34,6 @@ jobs:
         with:
           persist-credentials: false
 
-      # mise provides Go, golangci-lint, and Node (for the npm-vendored assets).
       - name: Setup Mise
         uses: jdx/mise-action@dba19683ed58901619b14f395a24841710cb4925 # v4.1.0
         with:
@@ -50,9 +49,6 @@ jobs:
           key: ${{ runner.os }}-go-${{ hashFiles('go.sum') }}
           restore-keys: ${{ runner.os }}-go-
 
-      # golangci-lint keeps its own analysis cache; give it a distinct key so it
-      # persists (reusing the Go cache key above would collide — a same-key entry
-      # with a different path never gets saved).
       - name: Cache golangci-lint
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
@@ -60,7 +56,6 @@ jobs:
           key: ${{ runner.os }}-golangci-lint-${{ hashFiles('go.sum', '.golangci.yml') }}
           restore-keys: ${{ runner.os }}-golangci-lint-
 
-      # //go:embed needs the assets present before the linter compiles the package.
       - name: Fetch build assets
         run: mise run assets
 

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -6,9 +6,13 @@ on:
   push:
     branches:
       - main
+    paths-ignore:
+      - "**.md"
   pull_request:
     branches:
       - main
+    paths-ignore:
+      - "**.md"
   workflow_dispatch:
 
 concurrency:
@@ -45,6 +49,16 @@ jobs:
             ~/go/pkg/mod
           key: ${{ runner.os }}-go-${{ hashFiles('go.sum') }}
           restore-keys: ${{ runner.os }}-go-
+
+      # golangci-lint keeps its own analysis cache; give it a distinct key so it
+      # persists (reusing the Go cache key above would collide — a same-key entry
+      # with a different path never gets saved).
+      - name: Cache golangci-lint
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: ~/.cache/golangci-lint
+          key: ${{ runner.os }}-golangci-lint-${{ hashFiles('go.sum', '.golangci.yml') }}
+          restore-keys: ${{ runner.os }}-golangci-lint-
 
       # //go:embed needs the assets present before the linter compiles the package.
       - name: Fetch build assets

--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -8,6 +8,10 @@ on:
       - main
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   release-please:
     runs-on: ubuntu-24.04

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -6,9 +6,16 @@ on:
   push:
     branches:
       - main
+    paths-ignore:
+      - "**.md"
   release:
     types:
       - published
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  # Cancel superseded main builds (rolling tag); never interrupt a published release.
+  cancel-in-progress: ${{ github.event_name != 'release' }}
 
 jobs:
   versions:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -14,7 +14,6 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  # Cancel superseded main builds (rolling tag); never interrupt a published release.
   cancel-in-progress: ${{ github.event_name != 'release' }}
 
 jobs:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -6,9 +6,13 @@ on:
   push:
     branches:
       - main
+    paths-ignore:
+      - "**.md"
   pull_request:
     branches:
       - main
+    paths-ignore:
+      - "**.md"
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
Three CI efficiency/correctness tweaks, from a review of recent run data.

### 1. Path-filter triggers (`paths-ignore: "**.md"`)
Tests, Lint, E2E (push + PR) and the **Release** `push` trigger now skip docs-only changes. A README/CHANGELOG edit no longer runs the Go suite, the kind-based Helm E2E (~2.4m), or — post-merge — a full multi-arch image build + push for the `rolling` tag (~3m). The `release: published` path is untouched, so real releases always build.

### 2. Concurrency groups on Release + Release Please
- **Release**: two quick merges to `main` no longer launch two parallel multi-arch builds that can finish out of order and leave `rolling`/`main` pointing at the *older* commit. `cancel-in-progress` is gated to non-release events, so a published release is never interrupted.
- **Release Please**: serialized so rapid pushes don't race on creating/updating the release PR (`cancel-in-progress: false`).

### 3. Dedicated golangci-lint cache
golangci-lint's analysis cache (`~/.cache/golangci-lint`) gets its own key. Folding it into the shared `-go-` cache key wouldn't work — a same-key/different-path entry never gets saved once another job writes that key first — so it needs a distinct `-golangci-lint-` namespace (keyed by `go.sum` + `.golangci.yml`).

### Notes
- Safe today because kromgo has **no required status checks**, so path-skipped runs don't leave checks "expected — waiting." If merge queues / required checks are adopted later, switch to job-level gating (the charts-mirror `action-changed-files` pattern) rather than `paths-ignore`.
- Deliberately **not** included from the review: per-job `timeout-minutes` (two prior runs hung ~15m before being cancelled), trimming the `versions` job's mise install, and caching the helm-unittest plugin — easy follow-ups if you want them.
- Applies equally to tuppr/konflate/kopiur (sibling workflows) if you want it rolled out.
