### PR TITLE
fix: bound HTTP timeouts, cap graph series, guard non-finite values

### DIFF
--- a/charts/kromgo/README.md
+++ b/charts/kromgo/README.md
@@ -94,8 +94,8 @@ Kubernetes: `>=1.25.0-0`
 | server.extraEnv | list | `[]` | Extra raw env vars merged into the container (advanced), e.g. GOMEMLIMIT. |
 | server.logging | bool | `false` | SERVER_LOGGING — per-request access logging. |
 | server.queryTimeout | string | `"30s"` | QUERY_TIMEOUT — bounds each outbound Prometheus query (Go duration). |
-| server.readTimeout | string | `""` | SERVER_READ_TIMEOUT (Go duration); empty = Go's default (no timeout). |
-| server.writeTimeout | string | `""` | SERVER_WRITE_TIMEOUT (Go duration); empty = Go's default (no timeout). |
+| server.readTimeout | string | `"15s"` | SERVER_READ_TIMEOUT (Go duration); "0" disables the read deadline. |
+| server.writeTimeout | string | `"60s"` | SERVER_WRITE_TIMEOUT (Go duration, must exceed queryTimeout); "0" disables it. |
 | service.metricsPort | int | `8888` | Health + /metrics port. |
 | service.port | int | `8080` | Badge / graph / gallery port. |
 | service.type | string | `"ClusterIP"` | Service type. |

--- a/charts/kromgo/values.schema.json
+++ b/charts/kromgo/values.schema.json
@@ -615,14 +615,14 @@
           "type": "string"
         },
         "readTimeout": {
-          "default": "",
-          "description": "SERVER_READ_TIMEOUT (Go duration); empty = Go's default (no timeout).",
+          "default": "15s",
+          "description": "SERVER_READ_TIMEOUT (Go duration); \"0\" disables the read deadline.",
           "title": "readTimeout",
           "type": "string"
         },
         "writeTimeout": {
-          "default": "",
-          "description": "SERVER_WRITE_TIMEOUT (Go duration); empty = Go's default (no timeout).",
+          "default": "60s",
+          "description": "SERVER_WRITE_TIMEOUT (Go duration, must exceed queryTimeout); \"0\" disables it.",
           "title": "writeTimeout",
           "type": "string"
         }

--- a/charts/kromgo/values.yaml
+++ b/charts/kromgo/values.yaml
@@ -112,13 +112,14 @@ config:
 server:
   # -- QUERY_TIMEOUT — bounds each outbound Prometheus query (Go duration).
   queryTimeout: 30s
-  # SERVER_READ_TIMEOUT / SERVER_WRITE_TIMEOUT — Go durations. Empty leaves Go's
-  # default (no timeout).
+  # SERVER_READ_TIMEOUT / SERVER_WRITE_TIMEOUT — Go durations bounding request read
+  # and response write on the public listener. The defaults harden against slow-client
+  # (Slowloris-style) connection holding; set either to "0" to disable its deadline.
 
-  # -- SERVER_READ_TIMEOUT (Go duration); empty = Go's default (no timeout).
-  readTimeout: ""
-  # -- SERVER_WRITE_TIMEOUT (Go duration); empty = Go's default (no timeout).
-  writeTimeout: ""
+  # -- SERVER_READ_TIMEOUT (Go duration); "0" disables the read deadline.
+  readTimeout: 15s
+  # -- SERVER_WRITE_TIMEOUT (Go duration, must exceed queryTimeout); "0" disables it.
+  writeTimeout: 60s
   # -- SERVER_LOGGING — per-request access logging.
   logging: false
   # -- Extra raw env vars merged into the container (advanced), e.g. GOMEMLIMIT.

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -116,7 +116,7 @@ func TestLoad_InvalidID(t *testing.T) {
 func TestLoadServer_Defaults(t *testing.T) {
 	// Clear any inherited env so envDefault applies. t.Setenv registers the
 	// restore; os.Unsetenv then removes the var for the duration of the test.
-	for _, k := range []string{"SERVER_PORT", "HEALTH_PORT", "QUERY_TIMEOUT", "SERVER_LOGGING"} {
+	for _, k := range []string{"SERVER_PORT", "HEALTH_PORT", "QUERY_TIMEOUT", "SERVER_LOGGING", "SERVER_READ_TIMEOUT", "SERVER_WRITE_TIMEOUT"} {
 		t.Setenv(k, "")
 		_ = os.Unsetenv(k)
 	}
@@ -126,6 +126,8 @@ func TestLoadServer_Defaults(t *testing.T) {
 	assert.Equal(t, 8080, sc.ServerPort)
 	assert.Equal(t, 8888, sc.HealthPort)
 	assert.Equal(t, 30*time.Second, sc.QueryTimeout)
+	assert.Equal(t, 15*time.Second, sc.ServerReadTimeout, "read timeout defaults to a bounded value, not 0")
+	assert.Equal(t, 60*time.Second, sc.ServerWriteTimeout, "write timeout defaults above QueryTimeout")
 	assert.False(t, sc.ServerLogging)
 }
 
@@ -133,9 +135,13 @@ func TestLoadServer_Overrides(t *testing.T) {
 	t.Setenv("SERVER_PORT", "9000")
 	t.Setenv("QUERY_TIMEOUT", "5s")
 	t.Setenv("SERVER_LOGGING", "true")
+	t.Setenv("SERVER_READ_TIMEOUT", "5s")
+	t.Setenv("SERVER_WRITE_TIMEOUT", "0") // 0 disables the deadline
 	sc, err := LoadServer()
 	require.NoError(t, err)
 	assert.Equal(t, 9000, sc.ServerPort)
 	assert.Equal(t, 5*time.Second, sc.QueryTimeout)
 	assert.True(t, sc.ServerLogging)
+	assert.Equal(t, 5*time.Second, sc.ServerReadTimeout)
+	assert.Equal(t, time.Duration(0), sc.ServerWriteTimeout, "0 disables the write deadline")
 }

--- a/internal/config/server.go
+++ b/internal/config/server.go
@@ -14,8 +14,12 @@ type ServerConfig struct {
 	HealthHost string `env:"HEALTH_HOST" envDefault:"0.0.0.0"`
 	HealthPort int    `env:"HEALTH_PORT" envDefault:"8888"`
 
-	ServerReadTimeout  time.Duration `env:"SERVER_READ_TIMEOUT"`
-	ServerWriteTimeout time.Duration `env:"SERVER_WRITE_TIMEOUT"`
+	// ServerReadTimeout / ServerWriteTimeout bound reading a request and writing its
+	// response on the public listener; the defaults harden against slow-client
+	// connection holding. WriteTimeout must exceed QueryTimeout so a slow upstream
+	// isn't cut off mid-render. Set either to "0" to disable (no deadline).
+	ServerReadTimeout  time.Duration `env:"SERVER_READ_TIMEOUT" envDefault:"15s"`
+	ServerWriteTimeout time.Duration `env:"SERVER_WRITE_TIMEOUT" envDefault:"60s"`
 	ServerLogging      bool          `env:"SERVER_LOGGING"`
 
 	// QueryTimeout bounds each outbound Prometheus query.

--- a/internal/kromgo/colors.go
+++ b/internal/kromgo/colors.go
@@ -1,16 +1,28 @@
 package kromgo
 
+import "math"
+
+// fallbackColor is the shields.io color name colorScale returns when it can't map a
+// value to a band — a NaN value, or a misconfigured steps/colors length.
+const fallbackColor = "grey"
+
 // colorScale is registered with the CEL environment (see expr.go) for a metric's
 // colorExpr, e.g. colorExpr: colorScale(result, [35.0, 75.0], ["green","orange","red"]).
 // It maps a value to a shields.io color name (resolved to hex later by colorNameToHex),
 // so threshold coloring isn't a hand-written chain of ternaries.
 //
 // It returns colors[i] for the first step where value < steps[i], otherwise the last
-// color; colors must hold exactly one more entry than steps. A misconfigured call
-// returns "grey" rather than erroring (kromgo degrades color, it never 500s on it).
+// color; colors must hold exactly one more entry than steps. A NaN value (or a
+// misconfigured call) returns "grey" rather than a color — kromgo degrades color, it
+// never 500s on it.
 func colorScale(value float64, steps []float64, colors []string) string {
 	if len(colors) != len(steps)+1 {
-		return "grey"
+		return fallbackColor
+	}
+	// NaN < step is always false, so a NaN would otherwise fall through every
+	// threshold to the last (worst) color — silently painting "missing" as "critical".
+	if math.IsNaN(value) {
+		return fallbackColor
 	}
 	for i, step := range steps {
 		if value < step {

--- a/internal/kromgo/colors_test.go
+++ b/internal/kromgo/colors_test.go
@@ -1,6 +1,7 @@
 package kromgo
 
 import (
+	"math"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -24,4 +25,7 @@ func TestColorScale(t *testing.T) {
 	// Misconfigured: colors must be exactly one longer than steps → "grey", not a panic.
 	assert.Equal(t, "grey", colorScale(50, steps, []string{"green", "red"}))
 	assert.Equal(t, "grey", colorScale(50, steps, nil))
+
+	// NaN must not fall through to the last (worst) color — it degrades to grey.
+	assert.Equal(t, "grey", colorScale(math.NaN(), steps, colors))
 }

--- a/internal/kromgo/formatting.go
+++ b/internal/kromgo/formatting.go
@@ -97,6 +97,9 @@ var durationUnits = []struct {
 // 40348800 -> "1y3mo12d". Negative input and anything that rounds to zero render
 // as "0s".
 func humanizeDuration(f float64) string {
+	if math.IsInf(f, 0) || math.IsNaN(f) {
+		return humanizeFloat(f) // "+Inf" / "-Inf" / "NaN" — int(NaN/Inf) is undefined in Go
+	}
 	rem := int(math.Round(f))
 	if rem <= 0 {
 		return "0s"
@@ -122,6 +125,9 @@ func humanizeDuration(f float64) string {
 // 5961600 -> "69d". Unlike humanizeDuration it never rolls up to months/years —
 // just total days, truncated and clamped at zero.
 func humanizeDurationDays(f float64) string {
+	if math.IsInf(f, 0) || math.IsNaN(f) {
+		return humanizeFloat(f) // "+Inf" / "-Inf" / "NaN" — int(NaN/Inf) is undefined in Go
+	}
 	days := int(f / 86400)
 	if days < 0 {
 		days = 0

--- a/internal/kromgo/formatting_test.go
+++ b/internal/kromgo/formatting_test.go
@@ -51,6 +51,9 @@ func TestHumanizers(t *testing.T) {
 		{"days truncates", humanizeDurationDays, 1.5 * day, "1d"},
 		{"days under a day", humanizeDurationDays, 3600, "0d"},
 		{"days clamped", humanizeDurationDays, -5, "0d"},
+		// Non-finite degrades to a clean string, not a garbage int(NaN/Inf) day count.
+		{"days NaN", humanizeDurationDays, math.NaN(), "NaN"},
+		{"days +Inf", humanizeDurationDays, math.Inf(1), "+Inf"},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -81,6 +84,10 @@ func TestHumanizeDuration(t *testing.T) {
 		// Edges.
 		{"zero", 0, "0s"},
 		{"negative clamped", -5, "0s"},
+		// Non-finite: int(NaN/Inf) is undefined, so guard before the conversion.
+		{"NaN", math.NaN(), "NaN"},
+		{"+Inf", math.Inf(1), "+Inf"},
+		{"-Inf", math.Inf(-1), "-Inf"},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/kromgo/graph.go
+++ b/internal/kromgo/graph.go
@@ -1,12 +1,21 @@
 package kromgo
 
 import (
+	"log/slog"
+	"math"
 	"net/http"
 	"time"
 
 	"github.com/home-operations/kromgo/internal/logging"
 	"github.com/prometheus/common/model"
 )
+
+// maxGraphSeries caps how many series a single graph response will encode or render.
+// The series count tracks the exposed metric's label cardinality, which is not
+// request-bounded and can spike at runtime (label churn); without a cap one public
+// request could materialize and draw thousands of lines. Excess series are dropped
+// and the truncation is logged. It is a fixed limit, like maxChartDimension.
+const maxGraphSeries = 100
 
 // HistoryDataPoint is one sample in a graph's JSON time series.
 type HistoryDataPoint struct {
@@ -69,6 +78,7 @@ func (h *Handler) serveGraph(w http.ResponseWriter, r *http.Request) {
 	if !ok {
 		return
 	}
+	matrix = capSeries(matrix, log)
 
 	if format == formatJSON {
 		writeJSONOr(w, log, id, historyResponse(graph, start, end, step, matrix))
@@ -86,13 +96,29 @@ func (h *Handler) serveGraph(w http.ResponseWriter, r *http.Request) {
 	_, _ = w.Write(img)
 }
 
+// capSeries truncates a matrix to maxGraphSeries, logging when it drops series so a
+// silent truncation doesn't read as "this is the whole result".
+func capSeries(matrix model.Matrix, log *slog.Logger) model.Matrix {
+	if len(matrix) <= maxGraphSeries {
+		return matrix
+	}
+	log.Warn("graph series truncated", "total", len(matrix), "cap", maxGraphSeries)
+	return matrix[:maxGraphSeries]
+}
+
 // historyResponse builds the JSON time-series payload from a query matrix.
 func historyResponse(graph *resolvedGraph, start, end time.Time, step time.Duration, matrix model.Matrix) HistoryResponse {
 	series := make([]HistorySeries, 0, len(matrix))
 	for _, stream := range matrix {
 		data := make([]HistoryDataPoint, 0, len(stream.Values))
 		for _, point := range stream.Values {
-			data = append(data, HistoryDataPoint{T: int64(point.Timestamp) / 1000, V: float64(point.Value)})
+			v := float64(point.Value)
+			// Skip non-finite samples: encoding/json errors on NaN/Inf (a single such
+			// sample would 500 the whole response), and the chart renders them as gaps.
+			if math.IsNaN(v) || math.IsInf(v, 0) {
+				continue
+			}
+			data = append(data, HistoryDataPoint{T: int64(point.Timestamp) / 1000, V: v})
 		}
 		series = append(series, HistorySeries{Labels: labelMap(stream.Metric), Data: data})
 	}

--- a/internal/kromgo/graph_test.go
+++ b/internal/kromgo/graph_test.go
@@ -1,0 +1,63 @@
+package kromgo
+
+import (
+	"encoding/json"
+	"log/slog"
+	"math"
+	"testing"
+	"time"
+
+	"github.com/home-operations/kromgo/internal/config"
+	"github.com/prometheus/common/model"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCapSeries(t *testing.T) {
+	t.Parallel()
+	mk := func(n int) model.Matrix {
+		m := make(model.Matrix, n)
+		for i := range m {
+			m[i] = &model.SampleStream{}
+		}
+		return m
+	}
+	// Under the cap: returned unchanged.
+	assert.Len(t, capSeries(mk(maxGraphSeries-1), slog.Default()), maxGraphSeries-1)
+	// At the cap: unchanged.
+	assert.Len(t, capSeries(mk(maxGraphSeries), slog.Default()), maxGraphSeries)
+	// Over the cap: truncated to the cap.
+	assert.Len(t, capSeries(mk(maxGraphSeries+25), slog.Default()), maxGraphSeries)
+}
+
+// A graph's range result routinely contains NaN/Inf samples (gaps, staleness,
+// x/0). encoding/json errors on those, so a single one would 500 the whole JSON
+// response; historyResponse must drop them, matching the chart's gap rendering.
+func TestHistoryResponse_SkipsNonFinite(t *testing.T) {
+	t.Parallel()
+	matrix := model.Matrix{{
+		Metric: model.Metric{"__name__": "up", "pod": "a"},
+		Values: []model.SamplePair{
+			{Timestamp: 1000, Value: 1.5},
+			{Timestamp: 2000, Value: model.SampleValue(math.NaN())},
+			{Timestamp: 3000, Value: model.SampleValue(math.Inf(1))},
+			{Timestamp: 4000, Value: model.SampleValue(math.Inf(-1))},
+			{Timestamp: 5000, Value: 2.5},
+		},
+	}}
+	resp := historyResponse(
+		&resolvedGraph{Graph: config.Graph{ID: "g", Title: "G"}},
+		time.Unix(0, 0), time.Unix(10, 0), time.Minute, matrix,
+	)
+
+	require.Len(t, resp.Series, 1)
+	data := resp.Series[0].Data
+	require.Len(t, data, 2, "only the two finite samples survive")
+	assert.Equal(t, 1.5, data[0].V)
+	assert.Equal(t, int64(1), data[0].T, "ms timestamp is divided to seconds")
+	assert.Equal(t, 2.5, data[1].V)
+
+	// The payload must marshal — a surviving NaN/Inf would make json.Marshal fail.
+	_, err := json.Marshal(resp)
+	require.NoError(t, err)
+}

--- a/internal/kromgo/instant.go
+++ b/internal/kromgo/instant.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"math"
 	"net/http"
 	"time"
 
@@ -74,7 +75,10 @@ func (h *Handler) serveBadge(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		v := float64(vector[0].Value)
-		message, color, result, labels = msg, col, &v, labelMap(vector[0].Metric)
+		message, color, labels = msg, col, labelMap(vector[0].Metric)
+		if !math.IsInf(v, 0) && !math.IsNaN(v) {
+			result = &v // omit a non-finite value: JSON can't encode NaN/Inf, and it isn't a real result
+		}
 	}
 
 	switch format {


### PR DESCRIPTION
Hardening from the code review, batched into one PR.

Closes #241
Closes #242
Closes #243

## #241 — bound the public listener's read/write timeouts

`SERVER_READ_TIMEOUT` / `SERVER_WRITE_TIMEOUT` had no `envDefault`, so a default deployment ran with both at `0` — Go's "no timeout". `ReadHeaderTimeout` (10s) guarded header-drip, but nothing bounded a slow **response** read, letting a slow client hold a connection (and its goroutine) indefinitely.

- `config/server.go`: default to `15s` read / `60s` write (write > `QueryTimeout` so a slow upstream isn't cut off mid-render). Set either to `"0"` to disable.
- `charts/kromgo/values.yaml`: `readTimeout`/`writeTimeout` now default to `15s`/`60s` (was `""`); README + schema regenerated.

> **Behaviour change:** a deployment that previously had no read/write deadline now gets one. Override via the env vars / chart values, or set `"0"` to keep it unbounded.

## #242 — cap graph series count

`renderChart` allocated one row per series and the JSON encoder buffered the whole result; per-series points were already bounded (`maxDuration`/step floor) but series **count** was not, tracking metric cardinality that can spike at runtime.

- `graph.go`: `capSeries` truncates a response to **100 series** (`maxGraphSeries`) for both render and JSON, logging a warning when it drops series so the truncation isn't silent. Mirrors the existing `maxChartDimension` cap.

## #243 — handle non-finite (NaN/±Inf) values

The range path already filtered non-finite samples; the instant path and the graph JSON path did not.

- `formatting.go`: `humanizeDuration` / `humanizeDurationDays` guard NaN/Inf (returning `"NaN"`/`"+Inf"` like `humanizeBytes` already does) instead of `int(NaN/Inf)`, which is undefined and rendered a misleading `"0s"`/`"0d"`.
- `colors.go`: `colorScale` returns `grey` for NaN instead of silently falling through every threshold to the last (worst) color.
- `instant.go`: omit a non-finite `result` from the badge JSON.
- `graph.go`: `historyResponse` skips non-finite samples. **`encoding/json` errors on NaN/Inf**, so without this a single such sample (common in range data — gaps, staleness, `x/0`) would `500` the entire `?format=json` response. This path wasn't named in #243 but is the same defect class, so it's fixed here too.

## Verification

`go build`, `go test ./internal/...`, `golangci-lint` (0 issues), `mise run generate` (idempotent), and `mise run test-e2e` (10/10) all pass. New tests: timeout defaults + `0`-disables (config), `humanizeDuration`/`Days` + `colorScale` non-finite cases, and `capSeries` + `historyResponse` non-finite skip (`graph_test.go`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
