### PR TITLE
ci(e2e): drop --wait from the helm-test cleanup so the job stops timing out

### DIFF
--- a/.mise/config.toml
+++ b/.mise/config.toml
@@ -112,9 +112,10 @@ description = "Install the chart into the current cluster (e.g. a kind context) 
 # review; locally these default to the published `latest` for a quick chart check
 # (the chart appVersion is a release-time placeholder, so a tag is always needed).
 # config.prometheus is never dialed at startup and /readyz is static, so the pod
-# becomes Ready without a real Prometheus. The trap cleans up.
+# becomes Ready without a real Prometheus. The trap cleans up (without --wait,
+# which can hang on teardown).
 run = """
-trap 'helm uninstall kromgo-e2e -n kromgo-e2e --wait >/dev/null 2>&1 || true' EXIT
+trap 'helm uninstall kromgo-e2e -n kromgo-e2e >/dev/null 2>&1 || true' EXIT
 set -e
 helm install kromgo-e2e charts/kromgo -n kromgo-e2e --create-namespace --wait --timeout 5m --set image.tag="${KROMGO_TEST_IMAGE_TAG:-latest}" --set image.pullPolicy="${KROMGO_TEST_PULL_POLICY:-IfNotPresent}"
 helm test kromgo-e2e -n kromgo-e2e --logs


### PR DESCRIPTION
## Problem
The **Helm E2E (kind)** job's cleanup trap runs `helm uninstall --wait` (no timeout). A Helm 4 `--wait` teardown hangs for minutes on even this trivial release — it already **cancelled this repo's `renovate/helm-4.x` e2e run at the 15-minute cap** (16:29:42 → 16:45:01), while `main` on Helm 4.2.0 passes in ~2.5 min.

## Fix
Drop `--wait` from the cleanup trap — the kind cluster is ephemeral in CI and a local re-run recreates the release, so cleanup needn't block. One line (plus a comment).

Same fix as konflate ([home-operations/konflate#211](https://github.com/home-operations/konflate/pull/211)); harmless on 4.2.0 and unblocks the Helm 4.x bump here.

```
gh pr merge ci/e2e-drop-uninstall-wait --squash --repo home-operations/kromgo
```