### PR TITLE
ci(e2e): remove the helm-test cleanup trap; use helm upgrade --install

### DIFF
--- a/.mise/config.toml
+++ b/.mise/config.toml
@@ -112,12 +112,10 @@ description = "Install the chart into the current cluster (e.g. a kind context) 
 # review; locally these default to the published `latest` for a quick chart check
 # (the chart appVersion is a release-time placeholder, so a tag is always needed).
 # config.prometheus is never dialed at startup and /readyz is static, so the pod
-# becomes Ready without a real Prometheus. The trap cleans up (without --wait,
-# which can hang on teardown).
+# becomes Ready without a real Prometheus.
 run = """
-trap 'helm uninstall kromgo-e2e -n kromgo-e2e >/dev/null 2>&1 || true' EXIT
 set -e
-helm install kromgo-e2e charts/kromgo -n kromgo-e2e --create-namespace --wait --timeout 5m --set image.tag="${KROMGO_TEST_IMAGE_TAG:-latest}" --set image.pullPolicy="${KROMGO_TEST_PULL_POLICY:-IfNotPresent}"
+helm upgrade --install kromgo-e2e charts/kromgo -n kromgo-e2e --create-namespace --wait --timeout 5m --set image.tag="${KROMGO_TEST_IMAGE_TAG:-latest}" --set image.pullPolicy="${KROMGO_TEST_PULL_POLICY:-IfNotPresent}"
 helm test kromgo-e2e -n kromgo-e2e --logs
 """
 


### PR DESCRIPTION
## What
Drop the `helm test` cleanup trap and switch `helm install` → `helm upgrade --install` in the `helm-test` task.

## Why
The trap's `helm uninstall` only ever served **local re-run hygiene** — `helm install` errors on a re-used release name. In **CI it's dead weight**: the kind cluster is created fresh per job and destroyed at the end. `helm upgrade --install` is idempotent, so local re-runs need no cleanup either.

Matches the sibling repos that don't uninstall at all. Follow-up to the `--wait` drop (already merged) — this removes the uninstall outright.

```
gh pr merge ci/e2e-drop-uninstall --squash --repo home-operations/kromgo
```