### PR TITLE
ci(e2e): cut the helm-test Helm-4 delete-wait, own-registry test image

### DIFF
--- a/charts/kromgo/README.md
+++ b/charts/kromgo/README.md
@@ -105,8 +105,8 @@ Kubernetes: `>=1.25.0-0`
 | serviceAccount.create | bool | `true` | Create a ServiceAccount. |
 | serviceAccount.name | string | `""` | ServiceAccount name; generated from the release name if empty. |
 | tests.image.pullPolicy | string | `"IfNotPresent"` | `helm test` image pull policy. |
-| tests.image.repository | string | `"mirror.gcr.io/busybox"` | `helm test` pod image; needs a shell with wget (kromgo's own image is from scratch). |
-| tests.image.tag | string | `"1.38.0@sha256:fd8d9aa63ba2f0982b5304e1ee8d3b90a210bc1ffb5314d980eb6962f1a9715d"` | `helm test` image, pinned as `tag@sha256:digest` so Renovate bumps the tag and its digest together. |
+| tests.image.repository | string | `"ghcr.io/home-operations/busybox"` | `helm test` pod image; needs a shell with wget (kromgo's own image is from scratch). |
+| tests.image.tag | string | `"1.38.0@sha256:7e2c04dd50ede647bf4a7a4c8dbd629dd4971cd139b9b88fb22bfc3c7a6c13df"` | `helm test` image, pinned as `tag@sha256:digest` so Renovate bumps the tag and its digest together. |
 | tolerations | list | `[]` | Tolerations for pod scheduling. |
 | volumeMounts | list | `[]` | Additional volume mounts on the container. |
 | volumes | list | `[]` | Additional volumes on the Deployment. |

--- a/charts/kromgo/templates/tests/test-connection.tpl
+++ b/charts/kromgo/templates/tests/test-connection.tpl
@@ -7,9 +7,11 @@ metadata:
     {{- include "kromgo.labels" . | nindent 4 }}
   annotations:
     helm.sh/hook: test
-    # Recreate on each run; keep the pod on failure so `helm test --logs` (and a
-    # manual `kubectl logs`) can show what happened.
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+    # before-hook-creation only (no hook-succeeded): `helm test` then never deletes
+    # the pod itself, so it can't block on Helm 4's wait-for-delete (kstatus) after a
+    # green run — which otherwise stalled `helm test` ~5m. The pod is recreated on
+    # the next run, and a failed run's pod stays for `helm test --logs` / kubectl.
+    helm.sh/hook-delete-policy: before-hook-creation
 spec:
   restartPolicy: Never
   securityContext:

--- a/charts/kromgo/values.schema.json
+++ b/charts/kromgo/values.schema.json
@@ -705,13 +705,13 @@
               "type": "string"
             },
             "repository": {
-              "default": "mirror.gcr.io/busybox",
+              "default": "ghcr.io/home-operations/busybox",
               "description": "`helm test` pod image; needs a shell with wget (kromgo's own image is from scratch).",
               "title": "repository",
               "type": "string"
             },
             "tag": {
-              "default": "1.38.0@sha256:fd8d9aa63ba2f0982b5304e1ee8d3b90a210bc1ffb5314d980eb6962f1a9715d",
+              "default": "1.38.0@sha256:7e2c04dd50ede647bf4a7a4c8dbd629dd4971cd139b9b88fb22bfc3c7a6c13df",
               "description": "`helm test` image, pinned as `tag",
               "title": "tag",
               "type": "string"

--- a/charts/kromgo/values.yaml
+++ b/charts/kromgo/values.yaml
@@ -301,8 +301,8 @@ volumeMounts: []
 tests:
   image:
     # -- `helm test` pod image; needs a shell with wget (kromgo's own image is from scratch).
-    repository: mirror.gcr.io/busybox
+    repository: ghcr.io/home-operations/busybox
     # -- `helm test` image, pinned as `tag@sha256:digest` so Renovate bumps the tag and its digest together.
-    tag: "1.38.0@sha256:fd8d9aa63ba2f0982b5304e1ee8d3b90a210bc1ffb5314d980eb6962f1a9715d"
+    tag: "1.38.0@sha256:7e2c04dd50ede647bf4a7a4c8dbd629dd4971cd139b9b88fb22bfc3c7a6c13df"
     # -- `helm test` image pull policy.
     pullPolicy: IfNotPresent


### PR DESCRIPTION
Two changes to the chart's `helm test`, after diagnosing the slow Helm E2E (install is ~12s; the rest was `helm test`):

### 1. Drop `hook-succeeded` from the test pod's delete-policy — the real ~5-min speed fix
After a green run, Helm 4 deletes the hook pod and **waits for that deletion via kstatus** — the same default-wait that hung `helm uninstall`. It silently stalled the test step ~5 min *after* the test passed. With `before-hook-creation` only, `helm test` returns immediately on success; the pod is recreated next run, kept on failure for `--logs`.

### 2. Test image → `ghcr.io/home-operations/busybox` — supply-chain hygiene
Uses the org's own image instead of the public mirror. **Not** a speed fix — the remaining ~5 min is the in-kind image *pull*, which is registry-independent. Kept per preference for our own registry.

`helm lint` clean; unittest regex still matches.