### PR TITLE
ci: emit OCI image labels and annotations via the builder

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -68,6 +68,8 @@ jobs:
       platforms: linux/amd64,linux/arm64
       push: true
       sbom: true
+      set-meta-annotations: true
+      set-meta-labels: true
       sign: true
     secrets:
       registry-auths: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,9 +33,6 @@ FROM scratch
 COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 COPY --from=builder /out/kromgo /kromgo
 EXPOSE 8080/tcp 8888/tcp
-LABEL \
-    org.opencontainers.image.title="kromgo" \
-    org.opencontainers.image.source="https://github.com/home-operations/kromgo"
 # Run as whatever UID you configure (k8s securityContext / docker --user); the
 # image pins no user.
 ENTRYPOINT ["/kromgo"]


### PR DESCRIPTION
Moves OCI image metadata to the builder so Renovate can resolve `org.opencontainers.image.source` and surface this image's changelog/release notes on dependency PRs.

`docker/github-builder` already runs `docker/metadata-action` (we pass `meta-images`/`meta-tags`) — it just wasn't applying the generated metadata. This flips on the two builder toggles:

- `set-meta-labels: true` — appends metadata-action's OCI **labels**, including `org.opencontainers.image.source` (the repo URL Renovate reads), plus `revision`, `created`, `title`, `version`, …
- `set-meta-annotations: true` — appends the matching OCI manifest **annotations** (best practice for multi-arch images).

…and **removes the now-redundant `LABEL org.opencontainers.image.*`** from the Dockerfile — the builder provides the same values (derived from git context), so there's no longer a hardcoded copy to drift.

Takes effect on the next release build. No app/runtime change.
