### PR TITLE
feat(badge): add for-the-badge style

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,7 +247,7 @@ fast rather than per request. Each expression receives two variables:
 
 - **`valueExpr`** must return a string — the message shown on the badge. Defaults to `string(result)`.
 - **`colorExpr`** must return a string — a [shields.io color name](https://shields.io) (`green`,
-  `orange`, `red`, `blue`, `grey`, …) or a hex value like `"#e05d44"`. Omit for no color.
+  `orange`, `red`, `blue`, `grey`, …) or a hex value like `"#dd4343"`. Omit for no color.
 
 Text color adapts to the background for legibility — dark text on light colors, white on dark — the
 same way shields.io does, so a light custom `colorExpr` stays readable. Every badge also carries

--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ defaults:
     badge:
         font: dejavu-sans # dejavu-sans (default, shields.io-style), dejavu-sans-bold, comic-neue, comic-neue-bold
         size: 11 # badge font size in points
-        style: flat # flat (default), flat-square, or plastic
+        style: flat # flat (default), flat-square, plastic, or for-the-badge
         gallery:
             hidden: false # list badges in the gallery (default); true hides them
     graph:
@@ -155,9 +155,28 @@ Each entry under `badges:` defines an instant-value endpoint at `/badges/{id}`.
 | `valueExpr`  | no       | CEL expression for the displayed string — see [Value and color](#value-and-color)    |
 | `colorExpr`  | no       | CEL expression for the color — see [Value and color](#value-and-color)               |
 | `labelColor` | no       | Left-segment (label) color — a name or hex; a fixed value, not a CEL expression      |
-| `style`      | no       | `flat` (default), `flat-square`, or `plastic`                                        |
+| `style`      | no       | `flat` (default), `flat-square`, `plastic`, or `for-the-badge` (see below)           |
 | `icon`       | no       | An icon on the SVG badge, e.g. `mdi:server-outline` or `si:kubernetes` — see below   |
 | `gallery`    | no       | Per-badge gallery settings, e.g. `gallery: {hidden: true}` — see [Gallery](#gallery) |
+
+#### Styles
+
+`flat` (the default), `flat-square`, and `plastic` are the familiar shields.io looks — a 20px badge
+that honors `defaults.badge.font`/`size`. `for-the-badge` is the chunky shields variant: a fixed 28px
+badge with **uppercased**, letter-spaced text and a bold value segment. Being a faithful port of
+shields' own geometry, it is **fixed-size** — it ignores `defaults.badge.font`/`size` (the value's
+bold weight is the configured face's bold companion). It pairs naturally with an `icon` and, with no
+`title`, collapses to a single logo+value segment — the shields "empty label" form:
+
+```yaml
+badges:
+    - id: kubernetes
+      query: kubernetes_build_info
+      valueExpr: labels[?"git_version"].orValue("unknown")
+      style: for-the-badge
+      icon: si:kubernetes
+      colorExpr: '"blue"'
+```
 
 #### Icons
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -67,7 +67,7 @@ type BadgeDefaults struct {
 	Font string `yaml:"font,omitempty" json:"font,omitempty"`
 	// Size is the font size in points (defaults to 11).
 	Size int `yaml:"size,omitempty" json:"size,omitempty"`
-	// Style is the default badge style: flat (default), flat-square, or plastic.
+	// Style is the default badge style: flat (default), flat-square, plastic, or for-the-badge.
 	Style string `yaml:"style,omitempty" json:"style,omitempty"`
 	// LabelColor is the default left-segment (label) color — a name or hex. Empty = grey (#555).
 	LabelColor string `yaml:"labelColor,omitempty" json:"labelColor,omitempty"`
@@ -200,9 +200,10 @@ const (
 	ReduceMax   = "max"
 	ReduceSum   = "sum"
 
-	StyleFlat       = "flat"
-	StyleFlatSquare = "flat-square"
-	StylePlastic    = "plastic"
+	StyleFlat        = "flat"
+	StyleFlatSquare  = "flat-square"
+	StylePlastic     = "plastic"
+	StyleForTheBadge = "for-the-badge"
 )
 
 // ValidReduce is the set of supported range-query reducers.
@@ -213,7 +214,7 @@ var ValidReduce = map[string]bool{
 
 // ValidStyle is the set of supported badge styles.
 var ValidStyle = map[string]bool{
-	StyleFlat: true, StyleFlatSquare: true, StylePlastic: true,
+	StyleFlat: true, StyleFlatSquare: true, StylePlastic: true, StyleForTheBadge: true,
 }
 
 // legacyKeys are top-level keys from the pre-0.12 schema; their presence triggers a

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -113,6 +113,22 @@ func TestLoad_InvalidID(t *testing.T) {
 	assert.Contains(t, err.Error(), "id must match")
 }
 
+func TestLoad_Style(t *testing.T) {
+	t.Parallel()
+	// Every supported style passes validation, both per-badge and as a default.
+	for _, style := range []string{StyleFlat, StyleFlatSquare, StylePlastic, StyleForTheBadge} {
+		_, err := Load(writeConfig(t, "badges:\n  - id: cpu\n    query: q\n    style: "+style+"\n"))
+		require.NoErrorf(t, err, "badge style %q should be valid", style)
+		_, err = Load(writeConfig(t, "defaults:\n  badge:\n    style: "+style+"\nbadges:\n  - id: cpu\n    query: q\n"))
+		require.NoErrorf(t, err, "default badge style %q should be valid", style)
+	}
+
+	// An unknown style is still rejected (guards ValidStyle staying authoritative).
+	_, err := Load(writeConfig(t, "badges:\n  - id: cpu\n    query: q\n    style: for-the-win\n"))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unknown style")
+}
+
 func TestLoadServer_Defaults(t *testing.T) {
 	// Clear any inherited env so envDefault applies. t.Setenv registers the
 	// restore; os.Unsetenv then removes the var for the duration of the test.

--- a/internal/kromgo/badge.go
+++ b/internal/kromgo/badge.go
@@ -22,11 +22,12 @@ const defaultBadgeFontSize = 11
 // segment widths always match the glyphs exactly. sfnt.Font is safe for concurrent
 // use as long as each call uses its own Buffer.
 type badgeRenderer struct {
-	font *sfnt.Font
-	size float64
+	font     *sfnt.Font // regular face: label text and the flat/flat-square/plastic styles
+	boldFont *sfnt.Font // bold companion: the for-the-badge message segment
+	size     float64
 }
 
-// newBadgeRenderer parses the configured font and returns a renderer.
+// newBadgeRenderer parses the configured font and its bold companion and returns a renderer.
 func newBadgeRenderer(cfg config.BadgeDefaults) (*badgeRenderer, error) {
 	data, err := resolveBadgeFont(cfg.Font)
 	if err != nil {
@@ -36,43 +37,71 @@ func newBadgeRenderer(cfg config.BadgeDefaults) (*badgeRenderer, error) {
 	if err != nil {
 		return nil, fmt.Errorf("parsing badge font: %w", err)
 	}
+	boldData, err := resolveBadgeBoldFont(cfg.Font)
+	if err != nil {
+		return nil, fmt.Errorf("badge bold font: %w", err)
+	}
+	bold, err := sfnt.Parse(boldData)
+	if err != nil {
+		return nil, fmt.Errorf("parsing badge bold font: %w", err)
+	}
 	size := float64(cfg.Size)
 	if size <= 0 {
 		size = defaultBadgeFontSize
 	}
-	return &badgeRenderer{font: f, size: size}, nil
+	return &badgeRenderer{font: f, boldFont: bold, size: size}, nil
 }
 
-func (b *badgeRenderer) ppem() fixed.Int26_6 { return fixed.Int26_6(b.size * 64) }
+func ppemFor(size float64) fixed.Int26_6 { return fixed.Int26_6(size * 64) }
 
-// measure returns the rendered width of s in pixels (sum of glyph advances).
-func (b *badgeRenderer) measure(s string) int {
+// measure returns the rendered width of s in pixels for the regular face at the
+// configured size, with no letter-spacing.
+func (b *badgeRenderer) measure(s string) int { return b.measureFace(b.font, s, b.size, 0) }
+
+// measureFace returns the rendered width of s in pixels: the sum of face f's glyph
+// advances at the given size, plus `tracking` px of letter-spacing after every glyph.
+// The tracking term is added in float space after the fixed→float conversion, so with
+// tracking == 0 the result is bit-identical to a plain advance sum (the flat path).
+func (b *badgeRenderer) measureFace(f *sfnt.Font, s string, size, tracking float64) int {
 	var buf sfnt.Buffer
 	var w fixed.Int26_6
+	ppem := ppemFor(size)
+	n := 0
 	for _, r := range s {
-		gid, err := b.font.GlyphIndex(&buf, r)
+		n++
+		gid, err := f.GlyphIndex(&buf, r)
 		if err != nil || gid == 0 {
-			w += fixed.Int26_6(b.size * 0.5 * 64) // fallback for a missing glyph
+			w += fixed.Int26_6(size * 0.5 * 64) // fallback for a missing glyph
 			continue
 		}
-		if adv, err := b.font.GlyphAdvance(&buf, gid, b.ppem(), font.HintingNone); err == nil {
+		if adv, err := f.GlyphAdvance(&buf, gid, ppem, font.HintingNone); err == nil {
 			w += adv
 		}
 	}
-	return int(float64(w)/64 + 0.5)
+	return int(float64(w)/64 + tracking*float64(n) + 0.5)
 }
 
-// glyphPath returns SVG path data for s, with the text baseline at (originX, baseline).
+// glyphPath returns SVG path data for s drawn with the regular face at the configured
+// size (no letter-spacing), with the text baseline at (originX, baseline).
 func (b *badgeRenderer) glyphPath(s string, originX, baseline float64) string {
+	return b.glyphPathFace(b.font, s, originX, baseline, b.size, 0)
+}
+
+// glyphPathFace returns SVG path data for s drawn with face f at the given size, the
+// text baseline at (originX, baseline), advancing `tracking` px after each glyph. The
+// per-glyph advance walk is unchanged from the plain path; the tracking step is guarded
+// so tracking == 0 reproduces it exactly.
+func (b *badgeRenderer) glyphPathFace(f *sfnt.Font, s string, originX, baseline, size, tracking float64) string {
 	var buf sfnt.Buffer
 	pen := originX
 	var d strings.Builder
+	ppem := ppemFor(size)
 	f26 := func(v fixed.Int26_6) float64 { return float64(v) / 64 }
 
 	for _, r := range s {
-		gid, err := b.font.GlyphIndex(&buf, r)
+		gid, err := f.GlyphIndex(&buf, r)
 		if err == nil && gid != 0 {
-			if segs, err := b.font.LoadGlyph(&buf, gid, b.ppem(), nil); err == nil {
+			if segs, err := f.LoadGlyph(&buf, gid, ppem, nil); err == nil {
 				for i, seg := range segs {
 					a := seg.Args
 					switch seg.Op {
@@ -94,10 +123,13 @@ func (b *badgeRenderer) glyphPath(s string, originX, baseline float64) string {
 				}
 			}
 		}
-		if adv, err := b.font.GlyphAdvance(&buf, gid, b.ppem(), font.HintingNone); err == nil {
+		if adv, err := f.GlyphAdvance(&buf, gid, ppem, font.HintingNone); err == nil {
 			pen += f26(adv)
 		} else {
-			pen += b.size * 0.5
+			pen += size * 0.5
+		}
+		if tracking != 0 {
+			pen += tracking
 		}
 	}
 	return d.String()
@@ -119,6 +151,9 @@ type badgeSpec struct {
 
 // render produces an SVG badge from a fully-resolved spec.
 func (b *badgeRenderer) render(spec badgeSpec) []byte {
+	if spec.style == config.StyleForTheBadge {
+		return b.renderForTheBadge(spec)
+	}
 	const (
 		xPad    = 6 // horizontal padding around each text segment
 		iconX   = 5 // icon left margin
@@ -242,17 +277,122 @@ func xmlIDSafe(s string) string {
 	}, s)
 }
 
-// writeText draws s as glyph paths at (originX, baseline) on a background of bgHex:
-// a 1px drop shadow beneath a fill, both colored for legibility on that background.
-// Nothing is written for empty text.
+// writeText draws s as glyph paths (regular face, configured size) at (originX, baseline)
+// on a background of bgHex. See emitTextPath.
 func (b *badgeRenderer) writeText(s *strings.Builder, text string, originX, baseline float64, bgHex string) {
-	d := b.glyphPath(text, originX, baseline)
+	b.emitTextPath(s, b.glyphPath(text, originX, baseline), bgHex)
+}
+
+// emitTextPath writes a rendered glyph path d as a 1px drop shadow beneath a fill, both
+// colored for legibility on a background of bgHex. Nothing is written for empty text.
+func (b *badgeRenderer) emitTextPath(s *strings.Builder, d, bgHex string) {
 	if d == "" {
 		return
 	}
 	textColor, shadowColor := colorsForBackground(bgHex)
 	fmt.Fprintf(s, `<path transform="translate(0 1)" fill="%s" fill-opacity=".3" d="%s"/>`, shadowColor, d)
 	fmt.Fprintf(s, `<path fill="%s" d="%s"/>`, textColor, d)
+}
+
+// for-the-badge geometry — a faithful port of shields.io's forTheBadge() renderer:
+// 28px tall, 10px UPPERCASE text with letter-spacing, a bold message segment, square
+// corners, and no gradient. Fixed-size (ignores defaults.badge.size), as in shields.
+const (
+	ftbHeight     = 28
+	ftbFontSize   = 10
+	ftbTracking   = 1.25 // letter-spacing: px advanced after each glyph
+	ftbTextMargin = 12   // text inset on each side of a segment
+	ftbLogoMargin = 9    // icon left margin
+	ftbLogoGutter = 6    // gap between icon and text
+	ftbIconSize   = 14   // == shields' for-the-badge logoWidth
+	ftbBaseline   = 17.5 // text baseline (shields y:175 at scale .1)
+)
+
+// renderForTheBadge draws the shields-style "for-the-badge" variant. The segment layout
+// mirrors shields' forTheBadge() line-for-line: kromgo draws left-aligned, exact-width
+// glyph paths at each segment's text-inset x, spanning the same range shields produces
+// with text-anchor=middle + textLength, so the width/position math ports directly. The
+// label uses the regular face; the message uses the bold companion (shields renders the
+// message bold). spec is never mutated, so the accessible label stays original-case.
+func (b *badgeRenderer) renderForTheBadge(spec badgeSpec) []byte {
+	label := strings.ToUpper(spec.label)
+	message := strings.ToUpper(spec.message)
+	hasLabel := label != ""
+	hasIcon := spec.iconPath != ""
+
+	labelW := 0
+	if hasLabel {
+		labelW = b.measureFace(b.font, label, ftbFontSize, ftbTracking)
+	}
+	msgW := b.measureFace(b.boldFont, message, ftbFontSize, ftbTracking)
+
+	// noText (no label and no message) collapses the icon gutter, matching shields.
+	gutter := ftbLogoGutter
+	if !hasLabel && message == "" {
+		gutter = ftbLogoGutter - ftbLogoMargin
+	}
+	// A label rect is drawn when there's label text, or an icon paired with an explicit
+	// labelColor (a colored logo box with no text).
+	needsLabelRect := hasLabel || (hasIcon && spec.labelColor != "")
+
+	logoMinX := ftbLogoMargin
+	labelTextMinX := ftbTextMargin
+	if hasIcon {
+		labelTextMinX = logoMinX + ftbIconSize + gutter
+	}
+
+	labelRectW := 0
+	var msgTextMinX, msgRectW int
+	switch {
+	case needsLabelRect:
+		if hasLabel {
+			labelRectW = labelTextMinX + labelW + ftbTextMargin
+		} else {
+			labelRectW = 2*ftbLogoMargin + ftbIconSize
+		}
+		msgTextMinX = labelRectW + ftbTextMargin
+		msgRectW = 2*ftbTextMargin + msgW
+	case hasIcon:
+		msgTextMinX = ftbTextMargin + ftbIconSize + gutter
+		msgRectW = 2*ftbTextMargin + ftbIconSize + gutter + msgW
+	default:
+		msgTextMinX = ftbTextMargin
+		msgRectW = 2*ftbTextMargin + msgW
+	}
+	total := labelRectW + msgRectW
+
+	msgHex := colorNameToHex(spec.color)
+	labelHex := cmp.Or(spec.labelColor, labelBg)
+	alt := html.EscapeString(accessibleText(spec.label, spec.message))
+	clipID := "r-" + xmlIDSafe(spec.id)
+
+	var s strings.Builder
+	fmt.Fprintf(&s, `<svg xmlns="http://www.w3.org/2000/svg" width="%d" height="%d" viewBox="0 0 %d %d" role="img" aria-label="%s">`, total, ftbHeight, total, ftbHeight, alt)
+	fmt.Fprintf(&s, `<title>%s</title>`, alt)
+	// Square corners, no gloss gradient (shields' crispEdges look).
+	fmt.Fprintf(&s, `<clipPath id="%s"><rect width="%d" height="%d" rx="0" fill="#fff"/></clipPath>`, clipID, total, ftbHeight)
+	fmt.Fprintf(&s, `<g clip-path="url(#%s)">`, clipID)
+	if labelRectW > 0 {
+		fmt.Fprintf(&s, `<rect width="%d" height="%d" fill="%s"/>`, labelRectW, ftbHeight, labelHex)
+	}
+	fmt.Fprintf(&s, `<rect x="%d" width="%d" height="%d" fill="%s"/>`, labelRectW, msgRectW, ftbHeight, msgHex)
+	if hasIcon {
+		// The icon sits on the label rect when there is one, else on the message rect.
+		iconBg := msgHex
+		if labelRectW > 0 {
+			iconBg = labelHex
+		}
+		iconColor, _ := colorsForBackground(iconBg)
+		scale := float64(ftbIconSize) / 24.0
+		fmt.Fprintf(&s, `<g transform="translate(%d %d) scale(%.4f)"><path fill="%s" d="%s"/></g>`,
+			logoMinX, (ftbHeight-ftbIconSize)/2, scale, iconColor, spec.iconPath)
+	}
+	if hasLabel {
+		b.emitTextPath(&s, b.glyphPathFace(b.font, label, float64(labelTextMinX), ftbBaseline, ftbFontSize, ftbTracking), labelHex)
+	}
+	b.emitTextPath(&s, b.glyphPathFace(b.boldFont, message, float64(msgTextMinX), ftbBaseline, ftbFontSize, ftbTracking), msgHex)
+	s.WriteString(`</g></svg>`)
+	return []byte(s.String())
 }
 
 // styleAppearance returns the corner radius and linear-gradient stops for a badge

--- a/internal/kromgo/badge.go
+++ b/internal/kromgo/badge.go
@@ -411,30 +411,36 @@ func styleAppearance(style string) (rx int, gradStops string) {
 
 var hexColorRe = regexp.MustCompile(`^#[0-9a-fA-F]{3,8}$`)
 
+// The current shields.io named-color palette, so a directly-rendered kromgo badge is
+// the same color as the same badge served through shields.io.
 const (
-	colorBlue  = "#007ec6"
-	colorGreen = "#97ca00"
-	colorGrey  = "#9f9f9f"
-	labelBg    = "#555" // label-side (left) background; always dark, so its text is white
+	colorBlue        = "#007ec6"
+	colorGreen       = "#67ac09"
+	colorBrightGreen = "#4b0"
+	colorOrange      = "#ea7233"
+	colorRed         = "#dd4343"
+	colorGrey        = "#939393" // lightgrey/lightgray/inactive
+	labelBg          = "#555"    // label-side (left) background; always dark, so its text is white
 )
 
-// badgeColors maps shields.io color names to hex. "" is the default (blue).
+// badgeColors maps shields.io color names to hex (the current shields.io palette). ""
+// is the default (blue).
 var badgeColors = map[string]string{
 	"":              colorBlue,
 	"blue":          colorBlue,
-	"brightgreen":   "#4c1",
+	"brightgreen":   colorBrightGreen,
 	"green":         colorGreen,
-	"yellow":        "#dfb317",
-	"yellowgreen":   "#a4a61d",
-	"orange":        "#fe7d37",
-	"red":           "#e05d44",
+	"yellow":        "#d8b800",
+	"yellowgreen":   "#95991a",
+	"orange":        colorOrange,
+	"red":           colorRed,
 	"grey":          "#555",
 	"gray":          "#555",
 	"lightgrey":     colorGrey,
 	"lightgray":     colorGrey,
-	"success":       colorGreen,
-	"important":     "#fe7d37",
-	"critical":      "#e05d44",
+	"success":       colorBrightGreen, // shields: success == brightgreen
+	"important":     colorOrange,
+	"critical":      colorRed,
 	"informational": colorBlue,
 	"inactive":      colorGrey,
 }

--- a/internal/kromgo/badge.go
+++ b/internal/kromgo/badge.go
@@ -278,19 +278,23 @@ func xmlIDSafe(s string) string {
 }
 
 // writeText draws s as glyph paths (regular face, configured size) at (originX, baseline)
-// on a background of bgHex. See emitTextPath.
+// on a background of bgHex, with a drop shadow. See emitTextPath.
 func (b *badgeRenderer) writeText(s *strings.Builder, text string, originX, baseline float64, bgHex string) {
-	b.emitTextPath(s, b.glyphPath(text, originX, baseline), bgHex)
+	b.emitTextPath(s, b.glyphPath(text, originX, baseline), bgHex, true)
 }
 
-// emitTextPath writes a rendered glyph path d as a 1px drop shadow beneath a fill, both
-// colored for legibility on a background of bgHex. Nothing is written for empty text.
-func (b *badgeRenderer) emitTextPath(s *strings.Builder, d, bgHex string) {
+// emitTextPath writes a rendered glyph path d as a fill colored for legibility on a
+// background of bgHex, optionally under a 1px drop shadow. Nothing is written for empty
+// text. flat/flat-square/plastic shadow their text (as shields.io does); for-the-badge
+// does not (shields.io renders for-the-badge text flat).
+func (b *badgeRenderer) emitTextPath(s *strings.Builder, d, bgHex string, shadow bool) {
 	if d == "" {
 		return
 	}
 	textColor, shadowColor := colorsForBackground(bgHex)
-	fmt.Fprintf(s, `<path transform="translate(0 1)" fill="%s" fill-opacity=".3" d="%s"/>`, shadowColor, d)
+	if shadow {
+		fmt.Fprintf(s, `<path transform="translate(0 1)" fill="%s" fill-opacity=".3" d="%s"/>`, shadowColor, d)
+	}
 	fmt.Fprintf(s, `<path fill="%s" d="%s"/>`, textColor, d)
 }
 
@@ -388,9 +392,9 @@ func (b *badgeRenderer) renderForTheBadge(spec badgeSpec) []byte {
 			logoMinX, (ftbHeight-ftbIconSize)/2, scale, iconColor, spec.iconPath)
 	}
 	if hasLabel {
-		b.emitTextPath(&s, b.glyphPathFace(b.font, label, float64(labelTextMinX), ftbBaseline, ftbFontSize, ftbTracking), labelHex)
+		b.emitTextPath(&s, b.glyphPathFace(b.font, label, float64(labelTextMinX), ftbBaseline, ftbFontSize, ftbTracking), labelHex, false)
 	}
-	b.emitTextPath(&s, b.glyphPathFace(b.boldFont, message, float64(msgTextMinX), ftbBaseline, ftbFontSize, ftbTracking), msgHex)
+	b.emitTextPath(&s, b.glyphPathFace(b.boldFont, message, float64(msgTextMinX), ftbBaseline, ftbFontSize, ftbTracking), msgHex, false)
 	s.WriteString(`</g></svg>`)
 	return []byte(s.String())
 }

--- a/internal/kromgo/badge_test.go
+++ b/internal/kromgo/badge_test.go
@@ -15,14 +15,17 @@ import (
 func TestColorNameToHex(t *testing.T) {
 	t.Parallel()
 	cases := map[string]string{
-		"":          "#007ec6", // default blue
-		"blue":      "#007ec6",
-		"green":     "#97ca00",
-		"red":       "#e05d44",
-		"inactive":  "#9f9f9f",
-		"#a1b2c3":   "#a1b2c3", // valid hex passes through
-		"#zzz":      "#97ca00", // invalid hex → fallback green
-		"notacolor": "#97ca00", // unknown name → fallback green
+		"":            "#007ec6", // default blue
+		"blue":        "#007ec6",
+		"green":       "#67ac09",
+		"brightgreen": "#4b0",
+		"orange":      "#ea7233",
+		"red":         "#dd4343",
+		"success":     "#4b0", // shields: success == brightgreen
+		"inactive":    "#939393",
+		"#a1b2c3":     "#a1b2c3", // valid hex passes through
+		"#zzz":        "#67ac09", // invalid hex → fallback green
+		"notacolor":   "#67ac09", // unknown name → fallback green
 	}
 	for in, want := range cases {
 		t.Run(in, func(t *testing.T) {
@@ -238,11 +241,11 @@ func TestBadgeRenderError(t *testing.T) {
 
 	// 4xx → red ("your request is wrong"); 5xx → grey ("couldn't get an answer").
 	client := string(r.renderError("cpu", "Not Found", 404))
-	assert.Contains(t, client, "#e05d44", "client errors are red")
+	assert.Contains(t, client, "#dd4343", "client errors are red")
 	assert.Contains(t, client, `aria-label="cpu: Not Found"`)
 
 	server := string(r.renderError("cpu", "Query Error", 500))
-	assert.Contains(t, server, "#9f9f9f", "server/upstream errors are grey")
+	assert.Contains(t, server, "#939393", "server/upstream errors are grey")
 	assert.Contains(t, server, `aria-label="cpu: Query Error"`)
 }
 

--- a/internal/kromgo/fonts.go
+++ b/internal/kromgo/fonts.go
@@ -3,6 +3,7 @@ package kromgo
 import (
 	_ "embed"
 	"fmt"
+	"strings"
 
 	"github.com/golang/freetype/truetype"
 )
@@ -42,6 +43,25 @@ func resolveBadgeFont(name string) ([]byte, error) {
 		return data, nil
 	}
 	return nil, fmt.Errorf("unknown font %q", name)
+}
+
+// resolveBadgeBoldFont returns the TTF bytes for the bold companion of a badge font
+// name — the face the for-the-badge style draws its (bold) message segment with. The
+// companion is "<name>-bold" (empty = dejavu-sans-bold, the default face's bold). A
+// name that is already a "-bold" face is its own companion. A face with no bundled
+// bold companion degrades gracefully to its regular bytes rather than erroring, so a
+// future regular-only face still renders for-the-badge (just not bold).
+func resolveBadgeBoldFont(name string) ([]byte, error) {
+	if name == "" {
+		return dejavuSansBoldTTF, nil
+	}
+	if strings.HasSuffix(name, "-bold") {
+		return resolveBadgeFont(name)
+	}
+	if data := embeddedFonts[name+"-bold"]; data != nil {
+		return data, nil
+	}
+	return resolveBadgeFont(name) // no bold companion — fall back to the regular face
 }
 
 // resolveGraphFont returns the parsed font for a graph font name (empty = the default

--- a/internal/kromgo/fonts_test.go
+++ b/internal/kromgo/fonts_test.go
@@ -1,6 +1,7 @@
 package kromgo
 
 import (
+	"bytes"
 	"testing"
 
 	"github.com/golang/freetype/truetype"
@@ -25,6 +26,30 @@ func TestEmbeddedFontsParse(t *testing.T) {
 			}
 			if _, err := truetype.Parse(data); err != nil {
 				t.Errorf("truetype parse (graph renderer): %v", err)
+			}
+		})
+	}
+}
+
+// TestResolveBadgeBoldFont covers the bold companion the for-the-badge message uses:
+// the default maps to dejavu-sans-bold, a regular face to its "-bold" sibling, a face
+// that is already bold to itself, and a face with no bold companion degrades to its
+// regular bytes rather than erroring.
+func TestResolveBadgeBoldFont(t *testing.T) {
+	cases := map[string][]byte{
+		"":                 dejavuSansBoldTTF,
+		"dejavu-sans":      dejavuSansBoldTTF,
+		"comic-neue":       comicNeueBoldTTF,
+		"dejavu-sans-bold": dejavuSansBoldTTF, // already bold → itself
+	}
+	for name, want := range cases {
+		t.Run(name, func(t *testing.T) {
+			got, err := resolveBadgeBoldFont(name)
+			if err != nil {
+				t.Fatalf("resolveBadgeBoldFont(%q): %v", name, err)
+			}
+			if !bytes.Equal(got, want) {
+				t.Errorf("resolveBadgeBoldFont(%q) returned the wrong face", name)
 			}
 		})
 	}

--- a/internal/kromgo/for_the_badge_test.go
+++ b/internal/kromgo/for_the_badge_test.go
@@ -1,0 +1,155 @@
+package kromgo
+
+import (
+	"bytes"
+	"encoding/xml"
+	"io"
+	"regexp"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/home-operations/kromgo/internal/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// firstGlyphBaselineY returns the y of the first "M<x> <y>" move command in svg —
+// for a badge with no icon, the first such command is a text glyph, so its y locates
+// the text baseline. Used to guard against a wildly-off / sign-flipped baseline.
+func firstGlyphBaselineY(t *testing.T, svg string) float64 {
+	t.Helper()
+	m := regexp.MustCompile(`M[\d.]+ ([\d.]+)`).FindStringSubmatch(svg)
+	require.Len(t, m, 2, "expected at least one glyph move command")
+	y, err := strconv.ParseFloat(m[1], 64)
+	require.NoError(t, err)
+	return y
+}
+
+func requireWellFormed(t *testing.T, svg []byte) {
+	t.Helper()
+	dec := xml.NewDecoder(bytes.NewReader(svg))
+	for {
+		_, err := dec.Token()
+		if err == io.EOF {
+			break
+		}
+		require.NoError(t, err, "rendered SVG must be well-formed XML")
+	}
+}
+
+func TestBadgeRender_ForTheBadge(t *testing.T) {
+	t.Parallel()
+	r, err := newBadgeRenderer(config.BadgeDefaults{})
+	require.NoError(t, err)
+
+	// Mixed-case input so the original-case accessible label is distinguishable from the
+	// uppercased glyphs — pins the "never mutate spec" invariant.
+	svg := r.render(badgeSpec{style: config.StyleForTheBadge, label: "build", message: "passing", color: "green", id: "b"})
+	s := string(svg)
+
+	requireWellFormed(t, svg)
+	assert.Contains(t, s, `height="28"`, "for-the-badge is 28px tall")
+	assert.Contains(t, s, `viewBox="0 0 `)
+	assert.Regexp(t, `viewBox="0 0 \d+ 28"`, s)
+	assert.Contains(t, s, `rx="0"`, "square corners")
+	assert.NotContains(t, s, "<linearGradient", "no gloss gradient")
+	assert.Contains(t, s, `aria-label="build: passing"`, "accessible label stays original-case")
+	assert.NotContains(t, s, "<text", "text is glyph paths, not <text>")
+
+	// Two segments (clip rect + label rect + message rect).
+	assert.Equal(t, 3, strings.Count(s, "<rect"), "label + message segments (plus the clip rect)")
+
+	// Strictly wider than the same flat badge: uppercase + 1.25 tracking + 12px margins.
+	flat := r.render(badgeSpec{style: config.StyleFlat, label: "build", message: "passing", color: "green", id: "b"})
+	assert.Greater(t, svgWidth(t, svg), svgWidth(t, flat), "for-the-badge is wider than flat")
+
+	// Baseline sits inside the 28px box (catches a negated/wildly-off baseline).
+	y := firstGlyphBaselineY(t, s)
+	assert.Greater(t, y, 7.0)
+	assert.Less(t, y, 21.0)
+}
+
+func TestBadgeRender_ForTheBadge_IconNoLabel(t *testing.T) {
+	t.Parallel()
+	r, err := newBadgeRenderer(config.BadgeDefaults{})
+	require.NoError(t, err)
+	icon, err := resolveIcon("si:kubernetes")
+	require.NoError(t, err)
+
+	// The home-ops hero shape: icon + message, no label, no labelColor → a single
+	// colored segment with the logo riding on it.
+	svg := r.render(badgeSpec{style: config.StyleForTheBadge, iconPath: icon, message: "v1.30.2", color: "blue", id: "k8s"})
+	s := string(svg)
+
+	requireWellFormed(t, svg)
+	assert.Contains(t, s, `height="28"`)
+	assert.Contains(t, s, icon, "icon path embedded")
+	assert.Equal(t, 2, strings.Count(s, "<rect"), "single message segment (plus the clip rect), no label box")
+	assert.Contains(t, s, `<rect x="0"`, "the single segment spans from the left edge")
+	assert.Contains(t, s, "#007ec6", "blue message segment")
+}
+
+func TestBadgeRender_ForTheBadge_IconLabelColor(t *testing.T) {
+	t.Parallel()
+	r, err := newBadgeRenderer(config.BadgeDefaults{})
+	require.NoError(t, err)
+	icon, err := resolveIcon("si:kubernetes")
+	require.NoError(t, err)
+
+	// Icon + explicit labelColor but no label → a colored logo box (labelRectWidth =
+	// 2*LOGO_MARGIN + logoWidth = 2*9 + 14 = 32) followed by the message segment.
+	svg := r.render(badgeSpec{style: config.StyleForTheBadge, iconPath: icon, message: "v1.30.2", color: "blue", labelColor: "purple", id: "k8s"})
+	s := string(svg)
+
+	requireWellFormed(t, svg)
+	assert.Equal(t, 3, strings.Count(s, "<rect"), "logo box + message segment (plus the clip rect)")
+	assert.Contains(t, s, `<rect width="32" height="28"`, "logo box is 2*9+14 = 32px wide")
+}
+
+func TestBadgeRender_ForTheBadge_NoText(t *testing.T) {
+	t.Parallel()
+	r, err := newBadgeRenderer(config.BadgeDefaults{})
+	require.NoError(t, err)
+	icon, err := resolveIcon("si:kubernetes")
+	require.NoError(t, err)
+
+	// Icon, empty message, no label exercises the noText gutter = LOGO_TEXT_GUTTER -
+	// LOGO_MARGIN (= -3) branch. It must still produce a well-formed, positive-width 28px
+	// badge with no panic.
+	svg := r.render(badgeSpec{style: config.StyleForTheBadge, iconPath: icon, message: "", color: "blue", id: "k8s"})
+	requireWellFormed(t, svg)
+	assert.Contains(t, string(svg), `height="28"`)
+	assert.Greater(t, svgWidth(t, svg), 0)
+}
+
+func TestBadgeRender_ForTheBadge_BoldMessage(t *testing.T) {
+	t.Parallel()
+	r, err := newBadgeRenderer(config.BadgeDefaults{})
+	require.NoError(t, err)
+	icon, err := resolveIcon("si:kubernetes")
+	require.NoError(t, err)
+
+	// The message segment must be drawn with the bold companion face. For the hero shape
+	// the message text is inset at TEXT_MARGIN + iconSize + gutter = 12 + 14 + 6 = 32.
+	const msgX = ftbTextMargin + ftbIconSize + ftbLogoGutter
+	boldPath := r.glyphPathFace(r.boldFont, "PASSING", msgX, ftbBaseline, ftbFontSize, ftbTracking)
+	regularPath := r.glyphPathFace(r.font, "PASSING", msgX, ftbBaseline, ftbFontSize, ftbTracking)
+	require.NotEqual(t, regularPath, boldPath, "bold and regular faces must differ for this text")
+
+	// Pass lowercase to also prove uppercasing: the rendered glyphs equal the bold path
+	// for "PASSING".
+	svg := string(r.render(badgeSpec{style: config.StyleForTheBadge, iconPath: icon, message: "passing", color: "blue", id: "x"}))
+	assert.Contains(t, svg, boldPath, "message rendered with the bold face (and uppercased)")
+	assert.NotContains(t, svg, regularPath, "message not rendered with the regular face")
+}
+
+// svgWidth extracts the integer width="" attribute from a rendered SVG.
+func svgWidth(t *testing.T, svg []byte) int {
+	t.Helper()
+	m := regexp.MustCompile(`width="(\d+)"`).FindSubmatch(svg)
+	require.Len(t, m, 2, "svg has a width attribute")
+	w, err := strconv.Atoi(string(m[1]))
+	require.NoError(t, err)
+	return w
+}

--- a/internal/kromgo/for_the_badge_test.go
+++ b/internal/kromgo/for_the_badge_test.go
@@ -64,6 +64,11 @@ func TestBadgeRender_ForTheBadge(t *testing.T) {
 	flat := r.render(badgeSpec{style: config.StyleFlat, label: "build", message: "passing", color: "green", id: "b"})
 	assert.Greater(t, svgWidth(t, svg), svgWidth(t, flat), "for-the-badge is wider than flat")
 
+	// for-the-badge text is flat (no drop shadow), as shields.io renders it — unlike
+	// flat/flat-square/plastic, which do shadow their text.
+	assert.NotContains(t, s, `fill-opacity=".3"`, "for-the-badge text has no drop shadow")
+	assert.Contains(t, string(flat), `fill-opacity=".3"`, "flat text keeps its drop shadow")
+
 	// Baseline sits inside the 28px box (catches a negated/wildly-off baseline).
 	y := firstGlyphBaselineY(t, s)
 	assert.Greater(t, y, 7.0)

--- a/internal/kromgo/handler_test.go
+++ b/internal/kromgo/handler_test.go
@@ -120,7 +120,7 @@ func TestServeBadge_Output(t *testing.T) {
 			assert.Equal(t, "image/svg+xml", w.Header().Get("Content-Type"))
 			assert.Equal(t, "no-store", w.Header().Get("Cache-Control"))
 			assert.Contains(t, w.Body.String(), `aria-label="does-not-exist: Not Found"`)
-			assert.Contains(t, w.Body.String(), "#e05d44") // red message segment
+			assert.Contains(t, w.Body.String(), "#dd4343") // red message segment
 		}},
 		{"not found json", "/badges/does-not-exist?format=json", func(t *testing.T, w *httptest.ResponseRecorder) {
 			// Non-svg formats keep the JSON error and its status code.

--- a/test/integration/gallery_test.go
+++ b/test/integration/gallery_test.go
@@ -109,7 +109,7 @@ func TestGallery(t *testing.T) {
 	group(&b, "Badge styles", func() {
 		// A different badge per style so they're easy to tell apart.
 		for _, sb := range []struct{ style, id string }{
-			{"flat", "cpu"}, {"flat-square", "pods"}, {"plastic", "mem"},
+			{"flat", "cpu"}, {"flat-square", "pods"}, {"plastic", "mem"}, {"for-the-badge", "mem"},
 		} {
 			bd := byID[sb.id]
 			bd.Style = sb.style


### PR DESCRIPTION
## Overview

 - adds a shields.io `for-the-badge` style (28px, uppercased, letter-spaced, bold value segment; pairs with an icon; collapses to single-segment with no title)
 - refreshes kromgo's stale named-color palette to align with the current shields.io palette
 - for-the-badge text renders flat (no drop shadow), matching shields.io
 
<img width="176" height="124" alt="forthebadge_1x" src="https://github.com/user-attachments/assets/dec23ca4-1833-4675-88dd-f5d22fafee5a" />

## Additional information

 - unit + e2e tests, golangci-lint clean
 - rendered against live shields.io for-the-badge: text width within ±1px, same height/weight/letter-spacing
 - live on my [home-ops readme](https://github.com/sholdee/home-ops/blob/master/README.md) with PR image build

## Requirements

- [x] I have read and agree with the [contributing guidelines](https://github.com/home-operations/.github/blob/main/CONTRIBUTING.md)
- [x] AI usage disclosure: Directed/reviewed/validated Claude output.