### PR TITLE
feat: move the monitoring port (health + metrics) to 8081

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,5 +30,5 @@ RUN upx --best --lzma /out/kromgo
 
 FROM gcr.io/distroless/static:nonroot
 COPY --from=builder /out/kromgo /kromgo
-EXPOSE 8080/tcp 8888/tcp
+EXPOSE 8080/tcp 8081/tcp
 ENTRYPOINT ["/kromgo"]

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ point your editor's YAML language server at it for inline completion and validat
 | `SERVER_HOST`          | no       | `0.0.0.0` | Host to bind the main server                |
 | `SERVER_PORT`          | no       | `8080`    | Port for the main server                    |
 | `HEALTH_HOST`          | no       | `0.0.0.0` | Host to bind the health server              |
-| `HEALTH_PORT`          | no       | `8888`    | Port for the health/metrics server          |
+| `HEALTH_PORT`          | no       | `8081`    | Port for the health/metrics server          |
 | `SERVER_LOGGING`       | no       | `false`   | Enable HTTP request access logging          |
 | `SERVER_READ_TIMEOUT`  | no       | —         | HTTP read timeout (e.g. `5s`)               |
 | `SERVER_WRITE_TIMEOUT` | no       | —         | HTTP write timeout (e.g. `10s`)             |
@@ -524,7 +524,7 @@ When nothing is visible the gallery shows a short hint instead.
 | Port   | Purpose                                                        |
 | ------ | -------------------------------------------------------------- |
 | `8080` | Main server — badge and graph endpoints                        |
-| `8888` | Health server — `/healthz`, `/readyz`, `/metrics` (Prometheus) |
+| `8081` | Health server — `/healthz`, `/readyz`, `/metrics` (Prometheus) |
 
 The health server's `/metrics` endpoint exposes Go runtime metrics plus
 `kromgo_requests_total{kind, id, format}` — a counter of requests handled, broken down by endpoint
@@ -677,7 +677,7 @@ kromgo is built to face the public web. Its posture:
 
 Operational guidance:
 
-- **Expose only the main port (`8080`).** The health port (`8888`) serves `/metrics` and probes —
+- **Expose only the main port (`8080`).** The health port (`8081`) serves `/metrics` and probes —
   keep it on the internal network.
 - **Terminate TLS and rate limit at your reverse proxy** (see [Rate limiting](#rate-limiting)).
 - Treat the config as trusted (it's operator-controlled). Fonts are compiled-in (never read from

--- a/charts/kromgo/README.md
+++ b/charts/kromgo/README.md
@@ -97,7 +97,7 @@ Kubernetes: `>=1.25.0-0`
 | server.queryTimeout | string | `"30s"` | QUERY_TIMEOUT — bounds each outbound Prometheus query (Go duration). |
 | server.readTimeout | string | `"15s"` | SERVER_READ_TIMEOUT (Go duration); "0" disables the read deadline. |
 | server.writeTimeout | string | `"60s"` | SERVER_WRITE_TIMEOUT (Go duration, must exceed queryTimeout); "0" disables it. |
-| service.metricsPort | int | `8888` | Health + /metrics port. |
+| service.metricsPort | int | `8081` | Health + /metrics port. |
 | service.port | int | `8080` | Badge / graph / gallery port. |
 | service.type | string | `"ClusterIP"` | Service type. |
 | serviceAccount.annotations | object | `{}` | Annotations for the ServiceAccount. |

--- a/charts/kromgo/templates/deployment.tpl
+++ b/charts/kromgo/templates/deployment.tpl
@@ -77,7 +77,7 @@ spec:
               containerPort: 8080
               protocol: TCP
             - name: health
-              containerPort: 8888
+              containerPort: 8081
               protocol: TCP
           livenessProbe:
             {{- tpl (toYaml .Values.livenessProbe) $ | nindent 12 }}

--- a/charts/kromgo/tests/test-connection_test.yaml
+++ b/charts/kromgo/tests/test-connection_test.yaml
@@ -20,4 +20,4 @@ tests:
           value: true
       - contains:
           path: spec.containers[0].args
-          content: http://RELEASE-NAME-kromgo:8888/readyz
+          content: http://RELEASE-NAME-kromgo:8081/readyz

--- a/charts/kromgo/values.schema.json
+++ b/charts/kromgo/values.schema.json
@@ -598,7 +598,7 @@
       "type": "object"
     },
     "server": {
-      "description": "Server tuning — kromgo's runtime environment variables (distinct from the\nconfig file above). SERVER_HOST/PORT and HEALTH_HOST/PORT are fixed by the\nchart (the Service and probes are wired to 8080 / 8888) and not exposed here.",
+      "description": "Server tuning — kromgo's runtime environment variables (distinct from the\nconfig file above). SERVER_HOST/PORT and HEALTH_HOST/PORT are fixed by the\nchart (the Service and probes are wired to 8080 / 8081) and not exposed here.",
       "properties": {
         "extraEnv": {
           "description": "Extra raw env vars merged into the container (advanced), e.g. GOMEMLIMIT.",
@@ -640,7 +640,7 @@
     "service": {
       "properties": {
         "metricsPort": {
-          "default": 8888,
+          "default": 8081,
           "description": "Health + /metrics port.",
           "title": "metricsPort",
           "type": "integer"

--- a/charts/kromgo/values.yaml
+++ b/charts/kromgo/values.yaml
@@ -108,7 +108,7 @@ config:
 
 # Server tuning — kromgo's runtime environment variables (distinct from the
 # config file above). SERVER_HOST/PORT and HEALTH_HOST/PORT are fixed by the
-# chart (the Service and probes are wired to 8080 / 8888) and not exposed here.
+# chart (the Service and probes are wired to 8080 / 8081) and not exposed here.
 server:
   # -- QUERY_TIMEOUT — bounds each outbound Prometheus query (Go duration).
   queryTimeout: 30s
@@ -185,7 +185,7 @@ service:
   # -- Badge / graph / gallery port.
   port: 8080
   # -- Health + /metrics port.
-  metricsPort: 8888
+  metricsPort: 8081
 
 ingress:
   # -- Expose the UI via an Ingress.

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -140,7 +140,7 @@ func TestLoadServer_Defaults(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "0.0.0.0", sc.ServerHost)
 	assert.Equal(t, 8080, sc.ServerPort)
-	assert.Equal(t, 8888, sc.HealthPort)
+	assert.Equal(t, 8081, sc.HealthPort)
 	assert.Equal(t, 30*time.Second, sc.QueryTimeout)
 	assert.Equal(t, 15*time.Second, sc.ServerReadTimeout, "read timeout defaults to a bounded value, not 0")
 	assert.Equal(t, 60*time.Second, sc.ServerWriteTimeout, "write timeout defaults above QueryTimeout")

--- a/internal/config/server.go
+++ b/internal/config/server.go
@@ -12,7 +12,7 @@ type ServerConfig struct {
 	ServerPort int    `env:"SERVER_PORT" envDefault:"8080"`
 
 	HealthHost string `env:"HEALTH_HOST" envDefault:"0.0.0.0"`
-	HealthPort int    `env:"HEALTH_PORT" envDefault:"8888"`
+	HealthPort int    `env:"HEALTH_PORT" envDefault:"8081"`
 
 	// ServerReadTimeout / ServerWriteTimeout bound reading a request and writing its
 	// response on the public listener; the defaults harden against slow-client


### PR DESCRIPTION
## What

Standardize kromgo's **monitoring port** (health probes + Prometheus `/metrics`) from **8888 → 8081**. kromgo already serves health and `/metrics` together on one listener, so this is a pure renumber.

The **web/badge port `8080` is unchanged.**

> [!IMPORTANT]
> This changes the **released default** monitoring port from `8888` to `8081`. Anyone scraping `/metrics` or hitting the health endpoints on `8888` (e.g. a hard-coded ServiceMonitor/NetworkPolicy, or a `HEALTH_PORT=8888` override) will need to update to `8081`. The chart's Service `metricsPort`, the Deployment health containerPort, and the in-chart probes all move together, so a plain chart upgrade keeps working without any value overrides.

## Changes (8888 → 8081)

| File | Change |
| ---- | ------ |
| `internal/config/server.go` | `HEALTH_PORT` `envDefault` |
| `internal/config/config_test.go` | `TestLoadServer_Defaults` expected `HealthPort` |
| `charts/kromgo/values.yaml` | `service.metricsPort` + the `server:` comment |
| `charts/kromgo/templates/deployment.tpl` | `health` container port |
| `charts/kromgo/tests/test-connection_test.yaml` | helm-unittest `/readyz` probe assertion |
| `Dockerfile` | `EXPOSE` (kept `8080/tcp`, changed `8888/tcp` → `8081/tcp`) |
| `README.md` | env table, Ports table, security guidance |
| `charts/kromgo/README.md`, `charts/kromgo/values.schema.json` | regenerated (`mise run generate`) |

## Verification

All green locally:

- `mise run test` — Go tests pass (config pkg 92.2% cov)
- `mise run lint` — golangci-lint, 0 issues
- `mise run vet` — clean
- `mise run helm-lint` — chart lints clean
- `mise run helm-unittest` — 16/16 pass (incl. the renumbered `/readyz` probe assertion)
- Generated files are consistent (a fresh `mise run generate` produces no further drift)
