### PR TITLE
feat!: serve health on the main port; metrics port becomes fully optional

### DIFF
--- a/.mise/mise.lock
+++ b/.mise/mise.lock
@@ -294,6 +294,7 @@ url = "https://registry.npmjs.org/npm/-/npm-11.18.0.tgz"
 url = "https://registry.npmjs.org/npm/-/npm-11.18.0.tgz"
 
 [tools.npm."platforms.macos-arm64"]
+checksum = "blake3:c92efa20f653b0179689b4e788f0a31e48fe2c855bb9a4d52066d5cdaf7aae0e"
 url = "https://registry.npmjs.org/npm/-/npm-11.18.0.tgz"
 
 [tools.npm."platforms.macos-x64"]

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ onto it. Notable values (see [`charts/kromgo/values.yaml`](charts/kromgo/values.
 | `secret.prometheusUrl` / `.existingSecret` | inject `PROMETHEUS_URL` from a Secret when the URL carries credentials        |
 | `ingress.enabled`                          | expose the app via an Ingress                                                 |
 | `httpRoute.enabled`                        | expose the app via a Gateway API `HTTPRoute` (set `parentRefs` + `hostnames`) |
-| `monitoring.serviceMonitor.enabled`        | scrape `/metrics` on the health port (Prometheus Operator)                    |
+| `monitoring.serviceMonitor.enabled`        | scrape `/metrics` on the metrics port (Prometheus Operator)                   |
 
 Every value is documented in the chart's generated README,
 [`charts/kromgo/README.md`](charts/kromgo/README.md), built from
@@ -101,19 +101,20 @@ point your editor's YAML language server at it for inline completion and validat
 
 ### Environment variables
 
-| Variable               | Required | Default   | Description                                 |
-| ---------------------- | -------- | --------- | ------------------------------------------- |
-| `PROMETHEUS_URL`       | yes      | —         | URL of your Prometheus instance             |
-| `SERVER_HOST`          | no       | `0.0.0.0` | Host to bind the main server                |
-| `SERVER_PORT`          | no       | `8080`    | Port for the main server                    |
-| `HEALTH_HOST`          | no       | `0.0.0.0` | Host to bind the health server              |
-| `HEALTH_PORT`          | no       | `8081`    | Port for the health/metrics server          |
-| `SERVER_LOGGING`       | no       | `false`   | Enable HTTP request access logging          |
-| `SERVER_READ_TIMEOUT`  | no       | —         | HTTP read timeout (e.g. `5s`)               |
-| `SERVER_WRITE_TIMEOUT` | no       | —         | HTTP write timeout (e.g. `10s`)             |
-| `QUERY_TIMEOUT`        | no       | `30s`     | Timeout applied to each Prometheus query    |
-| `LOG_LEVEL`            | no       | `info`    | Log level: `debug`, `info`, `warn`, `error` |
-| `LOG_FORMAT`           | no       | `json`    | Log format: `json` or `text`                |
+| Variable               | Required | Default | Description                                  |
+| ---------------------- | -------- | ------- | -------------------------------------------- |
+| `PROMETHEUS_URL`       | yes      | —       | URL of your Prometheus instance              |
+| `SERVER_HOST`          | no       | _(all)_ | Bind host; empty = all families (dual-stack) |
+| `SERVER_PORT`          | no       | `8080`  | Port for the main server                     |
+| `METRICS_HOST`         | no       | _(all)_ | Bind host for the metrics listener           |
+| `METRICS_ENABLED`      | no       | `true`  | Serve Prometheus /metrics; off ⇒ no listener |
+| `METRICS_PORT`         | no       | `8081`  | Metrics listen port (/metrics only)          |
+| `SERVER_LOGGING`       | no       | `false` | Enable HTTP request access logging           |
+| `SERVER_READ_TIMEOUT`  | no       | —       | HTTP read timeout (e.g. `5s`)                |
+| `SERVER_WRITE_TIMEOUT` | no       | —       | HTTP write timeout (e.g. `10s`)              |
+| `QUERY_TIMEOUT`        | no       | `30s`   | Timeout applied to each Prometheus query     |
+| `LOG_LEVEL`            | no       | `info`  | Log level: `debug`, `info`, `warn`, `error`  |
+| `LOG_FORMAT`           | no       | `json`  | Log format: `json` or `text`                 |
 
 ### Defaults
 
@@ -289,14 +290,14 @@ Besides CEL's built-ins (arithmetic, comparisons, ternary `?:`, `in`) the enviro
 On top of those, these formatting helpers are available (hand-rolled — kromgo has no external
 humanize dependency, so the output is exactly as below):
 
-| Function                       | Example                           | Result    | Notes                                       |
-| ------------------------------ | --------------------------------- | --------- | ------------------------------------------- |
+| Function                       | Example                           | Result    | Notes                                                      |
+| ------------------------------ | --------------------------------- | --------- | ---------------------------------------------------------- |
 | `humanize(result)`             | `humanize(93166031.0)`            | `93.17M`  | SI metric prefixes (powers of 1000), 4 sig figs, unit-less |
-| `humanizeBytes(result)`        | `humanizeBytes(1500000.0)`        | `1.5MB`   | SI decimal units (powers of 1000), no space |
-| `humanizeCommas(result)`       | `humanizeCommas(157121.0)`        | `157,121` | comma thousands grouping                    |
-| `humanizeFloat(result)`        | `humanizeFloat(2.50)`             | `2.5`     | plain decimal, trailing zeros stripped      |
-| `humanizeDuration(result)`     | `humanizeDuration(9000.0)`        | `2h30m`   | **seconds** → compact time span             |
-| `humanizeDurationDays(result)` | `humanizeDurationDays(5961600.0)` | `69d`     | **seconds** → whole days, no roll-up        |
+| `humanizeBytes(result)`        | `humanizeBytes(1500000.0)`        | `1.5MB`   | SI decimal units (powers of 1000), no space                |
+| `humanizeCommas(result)`       | `humanizeCommas(157121.0)`        | `157,121` | comma thousands grouping                                   |
+| `humanizeFloat(result)`        | `humanizeFloat(2.50)`             | `2.5`     | plain decimal, trailing zeros stripped                     |
+| `humanizeDuration(result)`     | `humanizeDuration(9000.0)`        | `2h30m`   | **seconds** → compact time span                            |
+| `humanizeDurationDays(result)` | `humanizeDurationDays(5961600.0)` | `69d`     | **seconds** → whole days, no roll-up                       |
 
 `humanizeDuration` takes **seconds** (so it drops onto a `time() - created_ts` query directly) and
 adapts to the magnitude, emitting the up-to-three most-significant units — `90` → `1m30s`, `9000` →
@@ -522,10 +523,10 @@ When nothing is visible the gallery shows a short hint instead.
 
 ## Ports
 
-| Port   | Purpose                                                        |
-| ------ | -------------------------------------------------------------- |
-| `8080` | Main server — badge and graph endpoints                        |
-| `8081` | Health server — `/healthz`, `/readyz`, `/metrics` (Prometheus) |
+| Port   | Purpose                                                               |
+| ------ | --------------------------------------------------------------------- |
+| `8080` | Main server — badge/graph endpoints + `/healthz`, `/readyz` probes    |
+| `8081` | Metrics server — `/metrics` (Prometheus); optional, off ⇒ no listener |
 
 The health server's `/metrics` endpoint exposes Go runtime metrics plus
 `kromgo_requests_total{kind, id, format}` — a counter of requests handled, broken down by endpoint
@@ -678,8 +679,8 @@ kromgo is built to face the public web. Its posture:
 
 Operational guidance:
 
-- **Expose only the main port (`8080`).** The health port (`8081`) serves `/metrics` and probes —
-  keep it on the internal network.
+- **Expose only the main port (`8080`).** The metrics port (`8081`) serves `/metrics` —
+  keep it on the internal network. Health probes ride the main port.
 - **Terminate TLS and rate limit at your reverse proxy** (see [Rate limiting](#rate-limiting)).
 - Treat the config as trusted (it's operator-controlled). Fonts are compiled-in (never read from
   disk), and CEL expressions run sandboxed (no env/file/network access).

--- a/charts/kromgo/README.md
+++ b/charts/kromgo/README.md
@@ -72,7 +72,7 @@ Kubernetes: `>=1.25.0-0`
 | ingress.enabled | bool | `false` | Expose the UI via an Ingress. |
 | ingress.hosts | list | `[{"host":"kromgo.example.com","paths":[{"path":"/","pathType":"Prefix"}]}]` | Ingress hosts and their paths. |
 | ingress.tls | list | `[]` | Ingress TLS configuration. |
-| livenessProbe | object | `{"httpGet":{"path":"/healthz","port":"health"},"initialDelaySeconds":10,"periodSeconds":20}` | Liveness probe. |
+| livenessProbe | object | `{"httpGet":{"path":"/healthz","port":"http"},"initialDelaySeconds":10,"periodSeconds":20}` | Liveness probe. Targets /healthz on the main http port, so it works regardless of the metrics toggle. |
 | monitoring.serviceMonitor.annotations | object | `{}` | ServiceMonitor annotations. |
 | monitoring.serviceMonitor.enabled | bool | `false` | Create a Prometheus Operator ServiceMonitor (requires its CRDs). |
 | monitoring.serviceMonitor.interval | string | `"30s"` | Scrape interval. |
@@ -86,7 +86,7 @@ Kubernetes: `>=1.25.0-0`
 | podAnnotations | object | `{}` | Annotations added to the pod. |
 | podLabels | object | `{}` | Labels added to the pod. |
 | podSecurityContext | object | `{"fsGroup":65532,"runAsGroup":65532,"runAsNonRoot":true,"runAsUser":65532,"seccompProfile":{"type":"RuntimeDefault"}}` | Pod-level securityContext (runs as non-root uid/gid 65532 with the RuntimeDefault seccomp profile). |
-| readinessProbe | object | `{"httpGet":{"path":"/readyz","port":"health"},"initialDelaySeconds":5,"periodSeconds":10}` | Readiness probe. |
+| readinessProbe | object | `{"httpGet":{"path":"/readyz","port":"http"},"initialDelaySeconds":5,"periodSeconds":10}` | Readiness probe. Targets /readyz on the main http port. |
 | replicaCount | int | `1` | Number of kromgo replicas (it queries Prometheus per request and is stateless behind the Service). |
 | resources | object | `{}` | Pod resource requests/limits. |
 | secret.existingSecret | string | `""` | Existing Secret with a PROMETHEUS_URL key; takes precedence over the inline value below. |
@@ -97,8 +97,9 @@ Kubernetes: `>=1.25.0-0`
 | server.queryTimeout | string | `"30s"` | QUERY_TIMEOUT — bounds each outbound Prometheus query (Go duration). |
 | server.readTimeout | string | `"15s"` | SERVER_READ_TIMEOUT (Go duration); "0" disables the read deadline. |
 | server.writeTimeout | string | `"60s"` | SERVER_WRITE_TIMEOUT (Go duration, must exceed queryTimeout); "0" disables it. |
-| service.metricsPort | int | `8081` | Health + /metrics port. |
-| service.port | int | `8080` | Badge / graph / gallery port. |
+| service.metricsEnabled | bool | `true` | Expose Prometheus metrics at /metrics on metricsPort (METRICS_ENABLED). Disabling removes the metrics listener, container port, and Service port entirely; health probes are unaffected (they target the http port). |
+| service.metricsPort | int | `8081` | Metrics listen port (/metrics only), kept off the public port. |
+| service.port | int | `8080` | Badge / graph / gallery port; also serves the /healthz and /readyz probes. |
 | service.type | string | `"ClusterIP"` | Service type. |
 | serviceAccount.annotations | object | `{}` | Annotations for the ServiceAccount. |
 | serviceAccount.automount | bool | `false` | Automount the ServiceAccount API token (off by default: kromgo talks to Prometheus, not the cluster API). |

--- a/charts/kromgo/templates/deployment.tpl
+++ b/charts/kromgo/templates/deployment.tpl
@@ -63,6 +63,10 @@ spec:
             - name: SERVER_LOGGING
               value: "true"
             {{- end }}
+            {{- if not .Values.service.metricsEnabled }}
+            - name: METRICS_ENABLED
+              value: "false"
+            {{- end }}
             {{- with .Values.server.extraEnv }}
             {{- tpl (toYaml .) $ | nindent 12 }}
             {{- end }}
@@ -76,9 +80,11 @@ spec:
             - name: http
               containerPort: 8080
               protocol: TCP
-            - name: health
+            {{- if .Values.service.metricsEnabled }}
+            - name: metrics
               containerPort: 8081
               protocol: TCP
+            {{- end }}
           livenessProbe:
             {{- tpl (toYaml .Values.livenessProbe) $ | nindent 12 }}
           readinessProbe:

--- a/charts/kromgo/templates/service.tpl
+++ b/charts/kromgo/templates/service.tpl
@@ -12,9 +12,11 @@ spec:
       port: {{ .Values.service.port }}
       targetPort: http
       protocol: TCP
+    {{- if .Values.service.metricsEnabled }}
     - name: metrics
       port: {{ .Values.service.metricsPort }}
-      targetPort: health
+      targetPort: metrics
       protocol: TCP
+    {{- end }}
   selector:
     {{- include "kromgo.selectorLabels" . | nindent 4 }}

--- a/charts/kromgo/templates/tests/test-connection.tpl
+++ b/charts/kromgo/templates/tests/test-connection.tpl
@@ -30,7 +30,7 @@ spec:
         capabilities:
           drop:
             - ALL
-      # /readyz on the health/metrics port returns a static 200 (no Prometheus
+      # /readyz on the main http port returns a static 200 (no Prometheus
       # dependency), so this checks purely that the Service routes to a running,
       # listening pod. curl -f fails on a non-2xx (or a refused connection), failing
       # `helm test`; -sS stays quiet but still surfaces errors, and the body goes to
@@ -39,4 +39,4 @@ spec:
         - curl
       args:
         - -fsS
-        - http://{{ include "kromgo.fullname" . }}:{{ .Values.service.metricsPort }}/readyz
+        - http://{{ include "kromgo.fullname" . }}:{{ .Values.service.port }}/readyz

--- a/charts/kromgo/tests/deployment_test.yaml
+++ b/charts/kromgo/tests/deployment_test.yaml
@@ -59,3 +59,28 @@ tests:
       - equal:
           path: spec.template.spec.automountServiceAccountToken
           value: false
+
+  # Pins the port standard: probes target the http port, and disabling metrics
+  # removes the metrics containerPort without touching them.
+  - it: keeps probes working when metrics are disabled
+    template: deployment.tpl
+    set:
+      service.metricsEnabled: false
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].ports
+          content:
+            name: metrics
+            containerPort: 8081
+            protocol: TCP
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: METRICS_ENABLED
+            value: "false"
+      - equal:
+          path: spec.template.spec.containers[0].livenessProbe.httpGet.port
+          value: http
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.httpGet.port
+          value: http

--- a/charts/kromgo/tests/test-connection_test.yaml
+++ b/charts/kromgo/tests/test-connection_test.yaml
@@ -20,4 +20,4 @@ tests:
           value: true
       - contains:
           path: spec.containers[0].args
-          content: http://RELEASE-NAME-kromgo:8081/readyz
+          content: http://RELEASE-NAME-kromgo:8080/readyz

--- a/charts/kromgo/values.schema.json
+++ b/charts/kromgo/values.schema.json
@@ -329,7 +329,7 @@
       "type": "object"
     },
     "livenessProbe": {
-      "description": "Liveness probe.",
+      "description": "Liveness probe. Targets /healthz on the main http port, so it works regardless of the metrics toggle.",
       "properties": {
         "httpGet": {
           "properties": {
@@ -339,7 +339,7 @@
               "type": "string"
             },
             "port": {
-              "default": "health",
+              "default": "http",
               "title": "port",
               "type": "string"
             }
@@ -494,7 +494,7 @@
       "type": "object"
     },
     "readinessProbe": {
-      "description": "Readiness probe.",
+      "description": "Readiness probe. Targets /readyz on the main http port.",
       "properties": {
         "httpGet": {
           "properties": {
@@ -504,7 +504,7 @@
               "type": "string"
             },
             "port": {
-              "default": "health",
+              "default": "http",
               "title": "port",
               "type": "string"
             }
@@ -639,15 +639,21 @@
     },
     "service": {
       "properties": {
+        "metricsEnabled": {
+          "default": true,
+          "description": "Expose Prometheus metrics at /metrics on metricsPort (METRICS_ENABLED). Disabling removes the metrics listener, container port, and Service port entirely; health probes are unaffected (they target the http port).",
+          "title": "metricsEnabled",
+          "type": "boolean"
+        },
         "metricsPort": {
           "default": 8081,
-          "description": "Health + /metrics port.",
+          "description": "Metrics listen port (/metrics only), kept off the public port.",
           "title": "metricsPort",
           "type": "integer"
         },
         "port": {
           "default": 8080,
-          "description": "Badge / graph / gallery port.",
+          "description": "Badge / graph / gallery port; also serves the /healthz and /readyz probes.",
           "title": "port",
           "type": "integer"
         },

--- a/charts/kromgo/values.yaml
+++ b/charts/kromgo/values.yaml
@@ -182,9 +182,11 @@ securityContext:
 service:
   # -- Service type.
   type: ClusterIP
-  # -- Badge / graph / gallery port.
+  # -- Badge / graph / gallery port; also serves the /healthz and /readyz probes.
   port: 8080
-  # -- Health + /metrics port.
+  # -- Expose Prometheus metrics at /metrics on metricsPort (METRICS_ENABLED). Disabling removes the metrics listener, container port, and Service port entirely; health probes are unaffected (they target the http port).
+  metricsEnabled: true
+  # -- Metrics listen port (/metrics only), kept off the public port.
   metricsPort: 8081
 
 ingress:
@@ -251,18 +253,18 @@ resources: {}
 #   cpu: 10m
 #   memory: 64Mi
 
-# -- Liveness probe.
+# -- Liveness probe. Targets /healthz on the main http port, so it works regardless of the metrics toggle.
 livenessProbe:
   httpGet:
     path: /healthz
-    port: health
+    port: http
   initialDelaySeconds: 10
   periodSeconds: 20
-# -- Readiness probe.
+# -- Readiness probe. Targets /readyz on the main http port.
 readinessProbe:
   httpGet:
     path: /readyz
-    port: health
+    port: http
   initialDelaySeconds: 5
   periodSeconds: 10
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -132,15 +132,17 @@ func TestLoad_Style(t *testing.T) {
 func TestLoadServer_Defaults(t *testing.T) {
 	// Clear any inherited env so envDefault applies. t.Setenv registers the
 	// restore; os.Unsetenv then removes the var for the duration of the test.
-	for _, k := range []string{"SERVER_PORT", "HEALTH_PORT", "QUERY_TIMEOUT", "SERVER_LOGGING", "SERVER_READ_TIMEOUT", "SERVER_WRITE_TIMEOUT"} {
+	for _, k := range []string{"SERVER_PORT", "METRICS_ENABLED", "METRICS_PORT", "QUERY_TIMEOUT", "SERVER_LOGGING", "SERVER_READ_TIMEOUT", "SERVER_WRITE_TIMEOUT"} {
 		t.Setenv(k, "")
 		_ = os.Unsetenv(k)
 	}
 	sc, err := LoadServer()
 	require.NoError(t, err)
-	assert.Equal(t, "0.0.0.0", sc.ServerHost)
+	// Empty host = the unspecified address (dual-stack), not IPv4-only 0.0.0.0.
+	assert.Empty(t, sc.ServerHost)
 	assert.Equal(t, 8080, sc.ServerPort)
-	assert.Equal(t, 8081, sc.HealthPort)
+	assert.True(t, sc.MetricsEnabled)
+	assert.Equal(t, 8081, sc.MetricsPort)
 	assert.Equal(t, 30*time.Second, sc.QueryTimeout)
 	assert.Equal(t, 15*time.Second, sc.ServerReadTimeout, "read timeout defaults to a bounded value, not 0")
 	assert.Equal(t, 60*time.Second, sc.ServerWriteTimeout, "write timeout defaults above QueryTimeout")

--- a/internal/config/server.go
+++ b/internal/config/server.go
@@ -8,11 +8,18 @@ import (
 
 // ServerConfig holds runtime server settings sourced from environment variables.
 type ServerConfig struct {
-	ServerHost string `env:"SERVER_HOST" envDefault:"0.0.0.0"`
+	// Hosts default to empty (the unspecified address), binding IPv4-only,
+	// IPv6-only, and dual-stack clusters alike; an explicit 0.0.0.0 would be
+	// IPv4-only. The main port also serves /healthz and /readyz.
+	ServerHost string `env:"SERVER_HOST" envDefault:""`
 	ServerPort int    `env:"SERVER_PORT" envDefault:"8080"`
 
-	HealthHost string `env:"HEALTH_HOST" envDefault:"0.0.0.0"`
-	HealthPort int    `env:"HEALTH_PORT" envDefault:"8081"`
+	// MetricsEnabled exposes Prometheus metrics at /metrics on MetricsPort.
+	// Disabling it removes the metrics listener entirely; the health probe
+	// endpoints live on the main port and are unaffected.
+	MetricsEnabled bool   `env:"METRICS_ENABLED" envDefault:"true"`
+	MetricsHost    string `env:"METRICS_HOST" envDefault:""`
+	MetricsPort    int    `env:"METRICS_PORT" envDefault:"8081"`
 
 	// ServerReadTimeout / ServerWriteTimeout bound reading a request and writing its
 	// response on the public listener; the defaults harden against slow-client

--- a/internal/server/health.go
+++ b/internal/server/health.go
@@ -6,13 +6,29 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
 
-// healthMux serves Prometheus metrics and liveness/readiness probes.
-func healthMux() *http.ServeMux {
+// healthPaths are the liveness/readiness endpoints, served on the MAIN port
+// (the org pair standard: /healthz = liveness, /readyz = readiness — aliases
+// here, kromgo has no serving condition beyond being up). The /-/ variants are
+// kept for backward compatibility.
+var healthPaths = []string{"/healthz", "/readyz", "/-/health", "/-/ready"}
+
+// withHealth overlays the health endpoints onto the application handler, so
+// probes work regardless of whether the optional metrics listener is enabled.
+func withHealth(app http.Handler) http.Handler {
 	mux := http.NewServeMux()
-	mux.Handle("GET /metrics", promhttp.Handler())
-	for _, path := range []string{"/healthz", "/-/health", "/readyz", "/-/ready"} {
+	for _, path := range healthPaths {
 		mux.HandleFunc("GET "+path, ok)
 	}
+	mux.Handle("/", app)
+	return mux
+}
+
+// metricsMux serves Prometheus metrics on the dedicated, optional metrics
+// listener. Health probes are NOT served here — they live on the main port, so
+// this whole listener can be disabled without breaking probes.
+func metricsMux() *http.ServeMux {
+	mux := http.NewServeMux()
+	mux.Handle("GET /metrics", promhttp.Handler())
 	return mux
 }
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -29,21 +29,26 @@ const (
 func Run(ctx context.Context, sc config.ServerConfig, app http.Handler) error {
 	main := &http.Server{
 		Addr:              net.JoinHostPort(sc.ServerHost, strconv.Itoa(sc.ServerPort)),
-		Handler:           withMiddleware(app, sc),
+		Handler:           withMiddleware(withHealth(app), sc),
 		ReadHeaderTimeout: readHeaderTimeout,
 		ReadTimeout:       sc.ServerReadTimeout,
 		WriteTimeout:      sc.ServerWriteTimeout,
 		IdleTimeout:       idleTimeout,
 	}
-	health := &http.Server{
-		Addr:              net.JoinHostPort(sc.HealthHost, strconv.Itoa(sc.HealthPort)),
-		Handler:           injectLogger(recoverer(secureHeaders(healthMux()))),
-		ReadHeaderTimeout: readHeaderTimeout,
-		ReadTimeout:       sc.ServerReadTimeout,
-		WriteTimeout:      sc.ServerWriteTimeout,
-		IdleTimeout:       idleTimeout,
+	servers := []*http.Server{main}
+	// The metrics listener is metrics-only and fully optional: /healthz and
+	// /readyz ride the main server above, so disabling metrics removes this
+	// port without touching the probes.
+	if sc.MetricsEnabled {
+		servers = append(servers, &http.Server{
+			Addr:              net.JoinHostPort(sc.MetricsHost, strconv.Itoa(sc.MetricsPort)),
+			Handler:           injectLogger(recoverer(secureHeaders(metricsMux()))),
+			ReadHeaderTimeout: readHeaderTimeout,
+			ReadTimeout:       sc.ServerReadTimeout,
+			WriteTimeout:      sc.ServerWriteTimeout,
+			IdleTimeout:       idleTimeout,
+		})
 	}
-	servers := []*http.Server{main, health}
 
 	errCh := make(chan error, len(servers))
 	for _, s := range servers {

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -28,18 +28,40 @@ func TestSecureHeaders(t *testing.T) {
 	assert.Contains(t, w.Header().Get("Content-Security-Policy"), "default-src 'none'")
 }
 
-func TestHealthMux(t *testing.T) {
+// TestWithHealth pins the pair standard: health probes ride the MAIN handler
+// (so the optional metrics listener can be disabled without breaking probes),
+// and the app still receives everything else.
+func TestWithHealth(t *testing.T) {
 	t.Parallel()
-	mux := healthMux()
-	for _, path := range []string{"/healthz", "/-/health", "/readyz", "/-/ready", "/metrics"} {
+	appHit := false
+	h := withHealth(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		appHit = true
+		w.WriteHeader(http.StatusOK)
+	}))
+	for _, path := range []string{"/healthz", "/readyz", "/-/health", "/-/ready"} {
 		t.Run(path, func(t *testing.T) {
-			t.Parallel()
 			req := httptest.NewRequest(http.MethodGet, path, nil)
 			w := httptest.NewRecorder()
-			mux.ServeHTTP(w, req)
+			h.ServeHTTP(w, req)
 			assert.Equal(t, http.StatusOK, w.Code)
+			assert.Equal(t, "OK", w.Body.String())
 		})
 	}
+	// Non-health paths fall through to the app.
+	h.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest(http.MethodGet, "/badges/x", nil))
+	assert.True(t, appHit)
+}
+
+// The metrics mux is metrics-only: health lives on the main port.
+func TestMetricsMux(t *testing.T) {
+	t.Parallel()
+	mux := metricsMux()
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/metrics", nil))
+	assert.Equal(t, http.StatusOK, w.Code)
+	w = httptest.NewRecorder()
+	mux.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/healthz", nil))
+	assert.Equal(t, http.StatusNotFound, w.Code)
 }
 
 func TestRecoverer_TurnsPanicInto500(t *testing.T) {
@@ -86,7 +108,8 @@ func TestRun_GracefulShutdown(t *testing.T) {
 	t.Parallel()
 	sc := config.ServerConfig{
 		ServerHost: "127.0.0.1", ServerPort: testutil.FreePort(t),
-		HealthHost: "127.0.0.1", HealthPort: testutil.FreePort(t),
+		MetricsEnabled: true,
+		MetricsHost:    "127.0.0.1", MetricsPort: testutil.FreePort(t),
 	}
 	app := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
@@ -96,8 +119,9 @@ func TestRun_GracefulShutdown(t *testing.T) {
 	done := make(chan error, 1)
 	go func() { done <- Run(ctx, sc, app) }()
 
-	// Wait until the health server is serving, then trigger graceful shutdown.
-	healthURL := fmt.Sprintf("http://127.0.0.1:%d/healthz", sc.HealthPort)
+	// Wait until the main server is serving (health rides it), then trigger
+	// graceful shutdown.
+	healthURL := fmt.Sprintf("http://127.0.0.1:%d/healthz", sc.ServerPort)
 	require.Eventually(t, func() bool {
 		resp, err := http.Get(healthURL)
 		if err != nil {

--- a/test/e2e/harness.go
+++ b/test/e2e/harness.go
@@ -37,11 +37,11 @@ graphs:
 `
 
 type harness struct {
-	t         *testing.T
-	baseURL   string
-	healthURL string
-	prom      *httptest.Server
-	cmd       *exec.Cmd
+	t          *testing.T
+	baseURL    string
+	metricsURL string
+	prom       *httptest.Server
+	cmd        *exec.Cmd
 }
 
 // start compiles kromgo, launches it against a mock Prometheus, and waits for readiness.
@@ -62,14 +62,14 @@ func start(t *testing.T) *harness {
 	require.NoError(t, os.WriteFile(configPath, []byte(configYAML), 0o600))
 
 	serverPort := testutil.FreePort(t)
-	healthPort := testutil.FreePort(t)
+	metricsPort := testutil.FreePort(t)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	cmd := exec.CommandContext(ctx, bin, "-config", configPath)
 	cmd.Env = append(os.Environ(),
 		"PROMETHEUS_URL="+prom.URL,
 		fmt.Sprintf("SERVER_PORT=%d", serverPort),
-		fmt.Sprintf("HEALTH_PORT=%d", healthPort),
+		fmt.Sprintf("METRICS_PORT=%d", metricsPort),
 		"LOG_FORMAT=text",
 	)
 	cmd.Stdout = os.Stderr
@@ -77,11 +77,11 @@ func start(t *testing.T) *harness {
 	require.NoError(t, cmd.Start())
 
 	h := &harness{
-		t:         t,
-		baseURL:   fmt.Sprintf("http://127.0.0.1:%d", serverPort),
-		healthURL: fmt.Sprintf("http://127.0.0.1:%d", healthPort),
-		prom:      prom,
-		cmd:       cmd,
+		t:          t,
+		baseURL:    fmt.Sprintf("http://127.0.0.1:%d", serverPort),
+		metricsURL: fmt.Sprintf("http://127.0.0.1:%d", metricsPort),
+		prom:       prom,
+		cmd:        cmd,
 	}
 	t.Cleanup(func() {
 		cancel()
@@ -94,14 +94,20 @@ func start(t *testing.T) *harness {
 
 func (h *harness) waitReady() {
 	h.t.Helper()
+	// Health rides the main port (the pair standard); the metrics listener is
+	// separate, so require both before tests run.
+	up := func(url string) bool {
+		resp, err := http.Get(url)
+		if err != nil {
+			return false
+		}
+		_ = resp.Body.Close()
+		return resp.StatusCode == http.StatusOK
+	}
 	deadline := time.Now().Add(15 * time.Second)
 	for time.Now().Before(deadline) {
-		resp, err := http.Get(h.healthURL + "/healthz")
-		if err == nil {
-			_ = resp.Body.Close()
-			if resp.StatusCode == http.StatusOK {
-				return
-			}
+		if up(h.baseURL+"/healthz") && up(h.metricsURL+"/metrics") {
+			return
 		}
 		time.Sleep(100 * time.Millisecond)
 	}


### PR DESCRIPTION
Rollout PR #3 of the org metrics/health standard (primary-HTTP tier + the `/healthz`+`/readyz` pair). Prior: home-operations/echo#28, home-operations/chaski#52 (both merged).

## What changed

- **`/healthz` + `/readyz` (and the legacy `/-/health`, `/-/ready` aliases) ride the main port (8080)** via a mux overlay in front of the app handler; the chart's probes and the helm-test hook target the `http` port.
- **The 8081 listener is metrics-only and truly optional** — new `METRICS_ENABLED` toggle (`service.metricsEnabled` in the chart); disabling removes the listener, container port, and Service port. New chart test pins probes-survive-metrics-off.
- **Bind rule:** `SERVER_HOST`/`METRICS_HOST` now default to the **unspecified address** (was `0.0.0.0`, which is IPv4-only and breaks IPv6-only clusters); ports render as `":<port>"`.
- **Names:** chart containerPort/Service port `health` → `metrics`; env `HEALTH_HOST`/`HEALTH_PORT` → `METRICS_HOST`/`METRICS_PORT`.
- e2e harness waits on both the main `/healthz` and the metrics `/metrics` before running.

## Breaking (hence `feat!`)

- `HEALTH_HOST`/`HEALTH_PORT` env renamed; `:8081/healthz|readyz` no longer served (move to the main port).
- Explicit `0.0.0.0` binds must now be set via env if genuinely wanted.
- Chart port name `health` → `metrics` (external scrape configs referencing the port *name* update; in-chart ServiceMonitor already used `metrics`).

## Verified

`mise run assets` + `go build`, `go test -race ./...`, **tagged e2e suite** (`mise run test-e2e` — required per repo convention for handler changes), `helm lint`, `helm unittest` 17/17, docs/schema regenerated, lint clean.

Next in rollout: konflate, then tuppr/litellm-operator/miroir (rule-2), then drm-exporter.
