### PR TITLE
feat!: prefix all environment variables with KROMGO_

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ The root path `/` serves a **gallery** that previews every endpoint next to its 
 
 ```bash
 docker run -d \
-  -e PROMETHEUS_URL=http://prometheus:9090 \
+  -e KROMGO_PROMETHEUS_URL=http://prometheus:9090 \
   -v /path/to/config.yaml:/config/config.yaml \
   -p 8080:8080 \
   ghcr.io/home-operations/kromgo:latest
@@ -45,7 +45,7 @@ services:
     kromgo:
         image: ghcr.io/home-operations/kromgo:latest
         environment:
-            PROMETHEUS_URL: http://prometheus:9090
+            KROMGO_PROMETHEUS_URL: http://prometheus:9090
         volumes:
             - ./config.yaml:/config/config.yaml:ro
         ports:
@@ -71,7 +71,7 @@ onto it. Notable values (see [`charts/kromgo/values.yaml`](charts/kromgo/values.
 | `config.prometheus`                        | Prometheus URL kromgo queries                                                 |
 | `config.badges` / `config.graphs`          | the endpoint definitions (same schema as the config file)                     |
 | `existingConfigMap`                        | mount a ConfigMap you manage elsewhere instead of rendering `config`          |
-| `secret.prometheusUrl` / `.existingSecret` | inject `PROMETHEUS_URL` from a Secret when the URL carries credentials        |
+| `secret.prometheusUrl` / `.existingSecret` | inject `KROMGO_PROMETHEUS_URL` from a Secret when the URL carries credentials |
 | `ingress.enabled`                          | expose the app via an Ingress                                                 |
 | `httpRoute.enabled`                        | expose the app via a Gateway API `HTTPRoute` (set `parentRefs` + `hostnames`) |
 | `monitoring.serviceMonitor.enabled`        | scrape `/metrics` on the metrics port (Prometheus Operator)                   |
@@ -101,20 +101,20 @@ point your editor's YAML language server at it for inline completion and validat
 
 ### Environment variables
 
-| Variable               | Required | Default | Description                                  |
-| ---------------------- | -------- | ------- | -------------------------------------------- |
-| `PROMETHEUS_URL`       | yes      | —       | URL of your Prometheus instance              |
-| `SERVER_HOST`          | no       | _(all)_ | Bind host; empty = all families (dual-stack) |
-| `SERVER_PORT`          | no       | `8080`  | Port for the main server                     |
-| `METRICS_HOST`         | no       | _(all)_ | Bind host for the metrics listener           |
-| `METRICS_ENABLED`      | no       | `true`  | Serve Prometheus /metrics; off ⇒ no listener |
-| `METRICS_PORT`         | no       | `8081`  | Metrics listen port (/metrics only)          |
-| `SERVER_LOGGING`       | no       | `false` | Enable HTTP request access logging           |
-| `SERVER_READ_TIMEOUT`  | no       | —       | HTTP read timeout (e.g. `5s`)                |
-| `SERVER_WRITE_TIMEOUT` | no       | —       | HTTP write timeout (e.g. `10s`)              |
-| `QUERY_TIMEOUT`        | no       | `30s`   | Timeout applied to each Prometheus query     |
-| `LOG_LEVEL`            | no       | `info`  | Log level: `debug`, `info`, `warn`, `error`  |
-| `LOG_FORMAT`           | no       | `json`  | Log format: `json` or `text`                 |
+| Variable                      | Required | Default | Description                                  |
+| ----------------------------- | -------- | ------- | -------------------------------------------- |
+| `KROMGO_PROMETHEUS_URL`       | yes      | —       | URL of your Prometheus instance              |
+| `KROMGO_SERVER_HOST`          | no       | _(all)_ | Bind host; empty = all families (dual-stack) |
+| `KROMGO_SERVER_PORT`          | no       | `8080`  | Port for the main server                     |
+| `KROMGO_METRICS_HOST`         | no       | _(all)_ | Bind host for the metrics listener           |
+| `KROMGO_METRICS_ENABLED`      | no       | `true`  | Serve Prometheus /metrics; off ⇒ no listener |
+| `KROMGO_METRICS_PORT`         | no       | `8081`  | Metrics listen port (/metrics only)          |
+| `KROMGO_SERVER_LOGGING`       | no       | `false` | Enable HTTP request access logging           |
+| `KROMGO_SERVER_READ_TIMEOUT`  | no       | —       | HTTP read timeout (e.g. `5s`)                |
+| `KROMGO_SERVER_WRITE_TIMEOUT` | no       | —       | HTTP write timeout (e.g. `10s`)              |
+| `KROMGO_QUERY_TIMEOUT`        | no       | `30s`   | Timeout applied to each Prometheus query     |
+| `KROMGO_LOG_LEVEL`            | no       | `info`  | Log level: `debug`, `info`, `warn`, `error`  |
+| `KROMGO_LOG_FORMAT`           | no       | `json`  | Log format: `json` or `text`                 |
 
 ### Defaults
 
@@ -670,9 +670,9 @@ kromgo is built to face the public web. Its posture:
 - **The gallery loads nothing external.** Its JS/CSS are embedded and served from `/assets/`, so the
   page ships a tightened-but-still-locked-down CSP (`script-src 'self'`, no `unsafe-inline`/`unsafe-eval`,
   no CDN). The Host header used to build snippet URLs is validated before use.
-- **Bounded work.** Each Prometheus query is bounded by `QUERY_TIMEOUT` (default 30s); graph windows
+- **Bounded work.** Each Prometheus query is bounded by `KROMGO_QUERY_TIMEOUT` (default 30s); graph windows
   are capped by `maxDuration` and image dimensions are clamped. A 10s `ReadHeaderTimeout` guards
-  against Slowloris; tune `SERVER_READ_TIMEOUT`/`SERVER_WRITE_TIMEOUT` to your proxy.
+  against Slowloris; tune `KROMGO_SERVER_READ_TIMEOUT`/`KROMGO_SERVER_WRITE_TIMEOUT` to your proxy.
 - **Minimal image.** A `scratch` image with just the static binary and a CA bundle (kromgo dials
   Prometheus over HTTPS) — no shell, package manager, or writable filesystem. It pins no user; set one
   via your Kubernetes `securityContext` or `docker run --user`. Images are cosign-signed (below).
@@ -738,9 +738,9 @@ Release tags drop the `v` prefix (e.g. `0.12.0`, not `v0.12.0`); pin image tags 
 
 This fork began as [kashalls/kromgo](https://github.com/kashalls/kromgo). Beyond the schema changes
 above, note: the image moved to `ghcr.io/home-operations/kromgo`; the badge font is no longer bundled
-(an embedded font is used, with `defaults.badge.font` to override); `LOG_FORMAT=test` was corrected
-to `LOG_FORMAT=text`; built-in rate limiting was removed (see [Rate limiting](#rate-limiting)); and a
-missing `PROMETHEUS_URL` now fails fast instead of starting degraded.
+(an embedded font is used, with `defaults.badge.font` to override); `KROMGO_LOG_FORMAT=test` was corrected
+to `KROMGO_LOG_FORMAT=text`; built-in rate limiting was removed (see [Rate limiting](#rate-limiting)); and a
+missing `KROMGO_PROMETHEUS_URL` now fails fast instead of starting degraded.
 
 ## Community
 

--- a/charts/kromgo/README.md
+++ b/charts/kromgo/README.md
@@ -89,15 +89,15 @@ Kubernetes: `>=1.25.0-0`
 | readinessProbe | object | `{"httpGet":{"path":"/readyz","port":"http"},"initialDelaySeconds":5,"periodSeconds":10}` | Readiness probe. Targets /readyz on the main http port. |
 | replicaCount | int | `1` | Number of kromgo replicas (it queries Prometheus per request and is stateless behind the Service). |
 | resources | object | `{}` | Pod resource requests/limits. |
-| secret.existingSecret | string | `""` | Existing Secret with a PROMETHEUS_URL key; takes precedence over the inline value below. |
-| secret.prometheusUrl | string | `""` | PROMETHEUS_URL — sensitive Prometheus URL; overrides config.prometheus when set. |
+| secret.existingSecret | string | `""` | Existing Secret with a KROMGO_PROMETHEUS_URL key; takes precedence over the inline value below. |
+| secret.prometheusUrl | string | `""` | KROMGO_PROMETHEUS_URL — sensitive Prometheus URL; overrides config.prometheus when set. |
 | securityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"readOnlyRootFilesystem":true}` | Container securityContext (no privilege escalation, read-only root filesystem, drops ALL capabilities). |
 | server.extraEnv | list | `[]` | Extra raw env vars merged into the container (advanced), e.g. GOMEMLIMIT. |
-| server.logging | bool | `false` | SERVER_LOGGING — per-request access logging. |
-| server.queryTimeout | string | `"30s"` | QUERY_TIMEOUT — bounds each outbound Prometheus query (Go duration). |
-| server.readTimeout | string | `"15s"` | SERVER_READ_TIMEOUT (Go duration); "0" disables the read deadline. |
-| server.writeTimeout | string | `"60s"` | SERVER_WRITE_TIMEOUT (Go duration, must exceed queryTimeout); "0" disables it. |
-| service.metricsEnabled | bool | `true` | Expose Prometheus metrics at /metrics on metricsPort (METRICS_ENABLED). Disabling removes the metrics listener, container port, and Service port entirely; health probes are unaffected (they target the http port). |
+| server.logging | bool | `false` | KROMGO_SERVER_LOGGING — per-request access logging. |
+| server.queryTimeout | string | `"30s"` | KROMGO_QUERY_TIMEOUT — bounds each outbound Prometheus query (Go duration). |
+| server.readTimeout | string | `"15s"` | KROMGO_SERVER_READ_TIMEOUT (Go duration); "0" disables the read deadline. |
+| server.writeTimeout | string | `"60s"` | KROMGO_SERVER_WRITE_TIMEOUT (Go duration, must exceed queryTimeout); "0" disables it. |
+| service.metricsEnabled | bool | `true` | Expose Prometheus metrics at /metrics on metricsPort (KROMGO_METRICS_ENABLED). Disabling removes the metrics listener, container port, and Service port entirely; health probes are unaffected (they target the http port). |
 | service.metricsPort | int | `8081` | Metrics listen port (/metrics only), kept off the public port. |
 | service.port | int | `8080` | Badge / graph / gallery port; also serves the /healthz and /readyz probes. |
 | service.type | string | `"ClusterIP"` | Service type. |

--- a/charts/kromgo/templates/deployment.tpl
+++ b/charts/kromgo/templates/deployment.tpl
@@ -49,32 +49,35 @@ spec:
           securityContext:
             {{- tpl (toYaml .Values.securityContext) $ | nindent 12 }}
           env:
-            - name: QUERY_TIMEOUT
+            - name: KROMGO_QUERY_TIMEOUT
               value: {{ tpl .Values.server.queryTimeout $ | quote }}
             {{- with .Values.server.readTimeout }}
-            - name: SERVER_READ_TIMEOUT
+            - name: KROMGO_SERVER_READ_TIMEOUT
               value: {{ tpl . $ | quote }}
             {{- end }}
             {{- with .Values.server.writeTimeout }}
-            - name: SERVER_WRITE_TIMEOUT
+            - name: KROMGO_SERVER_WRITE_TIMEOUT
               value: {{ tpl . $ | quote }}
             {{- end }}
             {{- if .Values.server.logging }}
-            - name: SERVER_LOGGING
+            - name: KROMGO_SERVER_LOGGING
               value: "true"
             {{- end }}
             {{- if not .Values.service.metricsEnabled }}
-            - name: METRICS_ENABLED
+            - name: KROMGO_METRICS_ENABLED
               value: "false"
             {{- end }}
             {{- with .Values.server.extraEnv }}
             {{- tpl (toYaml .) $ | nindent 12 }}
             {{- end }}
           {{- with (include "kromgo.secretName" .) }}
-          # PROMETHEUS_URL — overrides config.prometheus when present.
+          # The Secret key stays PROMETHEUS_URL (so existing Secrets keep
+          # working); the prefix injects it as KROMGO_PROMETHEUS_URL, which
+          # overrides config.prometheus when present.
           envFrom:
             - secretRef:
                 name: {{ . }}
+              prefix: KROMGO_
           {{- end }}
           ports:
             - name: http

--- a/charts/kromgo/tests/deployment_test.yaml
+++ b/charts/kromgo/tests/deployment_test.yaml
@@ -22,7 +22,7 @@ tests:
           path: spec.template.spec.containers[0].image
           value: ghcr.io/home-operations/kromgo@sha256:deadbeef
 
-  - it: renders QUERY_TIMEOUT through tpl
+  - it: renders KROMGO_QUERY_TIMEOUT through tpl
     template: deployment.tpl
     set:
       server.queryTimeout: "{{ .Release.Name }}"
@@ -30,10 +30,10 @@ tests:
       - contains:
           path: spec.template.spec.containers[0].env
           content:
-            name: QUERY_TIMEOUT
+            name: KROMGO_QUERY_TIMEOUT
             value: RELEASE-NAME
 
-  - it: omits SERVER_READ_TIMEOUT by default and emits it when set
+  - it: omits KROMGO_SERVER_READ_TIMEOUT by default and emits it when set
     template: deployment.tpl
     set:
       server.readTimeout: 5s
@@ -41,7 +41,7 @@ tests:
       - contains:
           path: spec.template.spec.containers[0].env
           content:
-            name: SERVER_READ_TIMEOUT
+            name: KROMGO_SERVER_READ_TIMEOUT
             value: "5s"
 
   - it: omits SERVER_LOGGING by default
@@ -76,7 +76,7 @@ tests:
       - contains:
           path: spec.template.spec.containers[0].env
           content:
-            name: METRICS_ENABLED
+            name: KROMGO_METRICS_ENABLED
             value: "false"
       - equal:
           path: spec.template.spec.containers[0].livenessProbe.httpGet.port

--- a/charts/kromgo/values.schema.json
+++ b/charts/kromgo/values.schema.json
@@ -541,17 +541,17 @@
       "type": "object"
     },
     "secret": {
-      "description": "Sensitive Prometheus URL — use when the endpoint embeds basic-auth credentials\nyou don't want in the ConfigMap. Provide it inline and a Secret is created, or\npoint at an existing Secret with a PROMETHEUS_URL key. Leave empty to use the\nplain `config.prometheus` above.",
+      "description": "Sensitive Prometheus URL — use when the endpoint embeds basic-auth credentials\nyou don't want in the ConfigMap. Provide it inline and a Secret is created, or\npoint at an existing Secret with a KROMGO_PROMETHEUS_URL key. Leave empty to use the\nplain `config.prometheus` above.",
       "properties": {
         "existingSecret": {
           "default": "",
-          "description": "Existing Secret with a PROMETHEUS_URL key; takes precedence over the inline value below.",
+          "description": "Existing Secret with a KROMGO_PROMETHEUS_URL key; takes precedence over the inline value below.",
           "title": "existingSecret",
           "type": "string"
         },
         "prometheusUrl": {
           "default": "",
-          "description": "PROMETHEUS_URL — sensitive Prometheus URL; overrides config.prometheus when set.",
+          "description": "KROMGO_PROMETHEUS_URL — sensitive Prometheus URL; overrides config.prometheus when set.",
           "title": "prometheusUrl",
           "type": "string"
         }
@@ -598,7 +598,7 @@
       "type": "object"
     },
     "server": {
-      "description": "Server tuning — kromgo's runtime environment variables (distinct from the\nconfig file above). SERVER_HOST/PORT and HEALTH_HOST/PORT are fixed by the\nchart (the Service and probes are wired to 8080 / 8081) and not exposed here.",
+      "description": "Server tuning — kromgo's runtime environment variables (distinct from the\nconfig file above). KROMGO_SERVER_PORT and KROMGO_METRICS_PORT are fixed by the\nchart (the Service and probes are wired to 8080 / 8081) and not exposed here.",
       "properties": {
         "extraEnv": {
           "description": "Extra raw env vars merged into the container (advanced), e.g. GOMEMLIMIT.",
@@ -610,25 +610,25 @@
         },
         "logging": {
           "default": false,
-          "description": "SERVER_LOGGING — per-request access logging.",
+          "description": "KROMGO_SERVER_LOGGING — per-request access logging.",
           "title": "logging",
           "type": "boolean"
         },
         "queryTimeout": {
           "default": "30s",
-          "description": "QUERY_TIMEOUT — bounds each outbound Prometheus query (Go duration).",
+          "description": "KROMGO_QUERY_TIMEOUT — bounds each outbound Prometheus query (Go duration).",
           "title": "queryTimeout",
           "type": "string"
         },
         "readTimeout": {
           "default": "15s",
-          "description": "SERVER_READ_TIMEOUT (Go duration); \"0\" disables the read deadline.",
+          "description": "KROMGO_SERVER_READ_TIMEOUT (Go duration); \"0\" disables the read deadline.",
           "title": "readTimeout",
           "type": "string"
         },
         "writeTimeout": {
           "default": "60s",
-          "description": "SERVER_WRITE_TIMEOUT (Go duration, must exceed queryTimeout); \"0\" disables it.",
+          "description": "KROMGO_SERVER_WRITE_TIMEOUT (Go duration, must exceed queryTimeout); \"0\" disables it.",
           "title": "writeTimeout",
           "type": "string"
         }
@@ -641,7 +641,7 @@
       "properties": {
         "metricsEnabled": {
           "default": true,
-          "description": "Expose Prometheus metrics at /metrics on metricsPort (METRICS_ENABLED). Disabling removes the metrics listener, container port, and Service port entirely; health probes are unaffected (they target the http port).",
+          "description": "Expose Prometheus metrics at /metrics on metricsPort (KROMGO_METRICS_ENABLED). Disabling removes the metrics listener, container port, and Service port entirely; health probes are unaffected (they target the http port).",
           "title": "metricsEnabled",
           "type": "boolean"
         },

--- a/charts/kromgo/values.yaml
+++ b/charts/kromgo/values.yaml
@@ -50,7 +50,7 @@ existingConfigMap: ""
 config:
   # Prometheus base URL kromgo queries. If the URL embeds credentials, leave this
   # empty and use `secret.prometheusUrl` (or `secret.existingSecret`) so it stays
-  # out of the ConfigMap — the Secret is injected as PROMETHEUS_URL, which
+  # out of the ConfigMap — the Secret is injected as KROMGO_PROMETHEUS_URL, which
   # overrides this value.
 
   # -- Prometheus base URL kromgo queries; use `secret.prometheusUrl` instead when it embeds credentials.
@@ -107,20 +107,20 @@ config:
   #     valueExpr: string(int(result)) + " pods"
 
 # Server tuning — kromgo's runtime environment variables (distinct from the
-# config file above). SERVER_HOST/PORT and HEALTH_HOST/PORT are fixed by the
+# config file above). KROMGO_SERVER_PORT and KROMGO_METRICS_PORT are fixed by the
 # chart (the Service and probes are wired to 8080 / 8081) and not exposed here.
 server:
-  # -- QUERY_TIMEOUT — bounds each outbound Prometheus query (Go duration).
+  # -- KROMGO_QUERY_TIMEOUT — bounds each outbound Prometheus query (Go duration).
   queryTimeout: 30s
-  # SERVER_READ_TIMEOUT / SERVER_WRITE_TIMEOUT — Go durations bounding request read
+  # KROMGO_SERVER_READ_TIMEOUT / KROMGO_SERVER_WRITE_TIMEOUT — Go durations bounding request read
   # and response write on the public listener. The defaults harden against slow-client
   # (Slowloris-style) connection holding; set either to "0" to disable its deadline.
 
-  # -- SERVER_READ_TIMEOUT (Go duration); "0" disables the read deadline.
+  # -- KROMGO_SERVER_READ_TIMEOUT (Go duration); "0" disables the read deadline.
   readTimeout: 15s
-  # -- SERVER_WRITE_TIMEOUT (Go duration, must exceed queryTimeout); "0" disables it.
+  # -- KROMGO_SERVER_WRITE_TIMEOUT (Go duration, must exceed queryTimeout); "0" disables it.
   writeTimeout: 60s
-  # -- SERVER_LOGGING — per-request access logging.
+  # -- KROMGO_SERVER_LOGGING — per-request access logging.
   logging: false
   # -- Extra raw env vars merged into the container (advanced), e.g. GOMEMLIMIT.
   extraEnv: []
@@ -129,15 +129,15 @@ server:
 
 # Sensitive Prometheus URL — use when the endpoint embeds basic-auth credentials
 # you don't want in the ConfigMap. Provide it inline and a Secret is created, or
-# point at an existing Secret with a PROMETHEUS_URL key. Leave empty to use the
+# point at an existing Secret with a KROMGO_PROMETHEUS_URL key. Leave empty to use the
 # plain `config.prometheus` above.
 secret:
-  # Pre-existing Secret with a PROMETHEUS_URL key. Takes precedence over the
+  # Pre-existing Secret with a KROMGO_PROMETHEUS_URL key. Takes precedence over the
   # inline value below.
 
-  # -- Existing Secret with a PROMETHEUS_URL key; takes precedence over the inline value below.
+  # -- Existing Secret with a KROMGO_PROMETHEUS_URL key; takes precedence over the inline value below.
   existingSecret: ""
-  # -- PROMETHEUS_URL — sensitive Prometheus URL; overrides config.prometheus when set.
+  # -- KROMGO_PROMETHEUS_URL — sensitive Prometheus URL; overrides config.prometheus when set.
   prometheusUrl: ""
 
 serviceAccount:
@@ -184,7 +184,7 @@ service:
   type: ClusterIP
   # -- Badge / graph / gallery port; also serves the /healthz and /readyz probes.
   port: 8080
-  # -- Expose Prometheus metrics at /metrics on metricsPort (METRICS_ENABLED). Disabling removes the metrics listener, container port, and Service port entirely; health probes are unaffected (they target the http port).
+  # -- Expose Prometheus metrics at /metrics on metricsPort (KROMGO_METRICS_ENABLED). Disabling removes the metrics listener, container port, and Service port entirely; health probes are unaffected (they target the http port).
   metricsEnabled: true
   # -- Metrics listen port (/metrics only), kept off the public port.
   metricsPort: 8081

--- a/cmd/kromgo/main.go
+++ b/cmd/kromgo/main.go
@@ -46,7 +46,7 @@ func run() error {
 		return fmt.Errorf("loading server config: %w", err)
 	}
 
-	prom, err := prometheus.New(cmp.Or(os.Getenv("PROMETHEUS_URL"), cfg.Prometheus), sc.QueryTimeout)
+	prom, err := prometheus.New(cmp.Or(os.Getenv("KROMGO_PROMETHEUS_URL"), cfg.Prometheus), sc.QueryTimeout)
 	if err != nil {
 		return err
 	}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -132,7 +132,7 @@ func TestLoad_Style(t *testing.T) {
 func TestLoadServer_Defaults(t *testing.T) {
 	// Clear any inherited env so envDefault applies. t.Setenv registers the
 	// restore; os.Unsetenv then removes the var for the duration of the test.
-	for _, k := range []string{"SERVER_PORT", "METRICS_ENABLED", "METRICS_PORT", "QUERY_TIMEOUT", "SERVER_LOGGING", "SERVER_READ_TIMEOUT", "SERVER_WRITE_TIMEOUT"} {
+	for _, k := range []string{"KROMGO_SERVER_PORT", "KROMGO_METRICS_ENABLED", "KROMGO_METRICS_PORT", "KROMGO_QUERY_TIMEOUT", "KROMGO_SERVER_LOGGING", "KROMGO_SERVER_READ_TIMEOUT", "KROMGO_SERVER_WRITE_TIMEOUT"} {
 		t.Setenv(k, "")
 		_ = os.Unsetenv(k)
 	}
@@ -150,11 +150,11 @@ func TestLoadServer_Defaults(t *testing.T) {
 }
 
 func TestLoadServer_Overrides(t *testing.T) {
-	t.Setenv("SERVER_PORT", "9000")
-	t.Setenv("QUERY_TIMEOUT", "5s")
-	t.Setenv("SERVER_LOGGING", "true")
-	t.Setenv("SERVER_READ_TIMEOUT", "5s")
-	t.Setenv("SERVER_WRITE_TIMEOUT", "0") // 0 disables the deadline
+	t.Setenv("KROMGO_SERVER_PORT", "9000")
+	t.Setenv("KROMGO_QUERY_TIMEOUT", "5s")
+	t.Setenv("KROMGO_SERVER_LOGGING", "true")
+	t.Setenv("KROMGO_SERVER_READ_TIMEOUT", "5s")
+	t.Setenv("KROMGO_SERVER_WRITE_TIMEOUT", "0") // 0 disables the deadline
 	sc, err := LoadServer()
 	require.NoError(t, err)
 	assert.Equal(t, 9000, sc.ServerPort)

--- a/internal/config/server.go
+++ b/internal/config/server.go
@@ -11,26 +11,26 @@ type ServerConfig struct {
 	// Hosts default to empty (the unspecified address), binding IPv4-only,
 	// IPv6-only, and dual-stack clusters alike; an explicit 0.0.0.0 would be
 	// IPv4-only. The main port also serves /healthz and /readyz.
-	ServerHost string `env:"SERVER_HOST" envDefault:""`
-	ServerPort int    `env:"SERVER_PORT" envDefault:"8080"`
+	ServerHost string `env:"KROMGO_SERVER_HOST" envDefault:""`
+	ServerPort int    `env:"KROMGO_SERVER_PORT" envDefault:"8080"`
 
 	// MetricsEnabled exposes Prometheus metrics at /metrics on MetricsPort.
 	// Disabling it removes the metrics listener entirely; the health probe
 	// endpoints live on the main port and are unaffected.
-	MetricsEnabled bool   `env:"METRICS_ENABLED" envDefault:"true"`
-	MetricsHost    string `env:"METRICS_HOST" envDefault:""`
-	MetricsPort    int    `env:"METRICS_PORT" envDefault:"8081"`
+	MetricsEnabled bool   `env:"KROMGO_METRICS_ENABLED" envDefault:"true"`
+	MetricsHost    string `env:"KROMGO_METRICS_HOST" envDefault:""`
+	MetricsPort    int    `env:"KROMGO_METRICS_PORT" envDefault:"8081"`
 
 	// ServerReadTimeout / ServerWriteTimeout bound reading a request and writing its
 	// response on the public listener; the defaults harden against slow-client
 	// connection holding. WriteTimeout must exceed QueryTimeout so a slow upstream
 	// isn't cut off mid-render. Set either to "0" to disable (no deadline).
-	ServerReadTimeout  time.Duration `env:"SERVER_READ_TIMEOUT" envDefault:"15s"`
-	ServerWriteTimeout time.Duration `env:"SERVER_WRITE_TIMEOUT" envDefault:"60s"`
-	ServerLogging      bool          `env:"SERVER_LOGGING"`
+	ServerReadTimeout  time.Duration `env:"KROMGO_SERVER_READ_TIMEOUT" envDefault:"15s"`
+	ServerWriteTimeout time.Duration `env:"KROMGO_SERVER_WRITE_TIMEOUT" envDefault:"60s"`
+	ServerLogging      bool          `env:"KROMGO_SERVER_LOGGING"`
 
 	// QueryTimeout bounds each outbound Prometheus query.
-	QueryTimeout time.Duration `env:"QUERY_TIMEOUT" envDefault:"30s"`
+	QueryTimeout time.Duration `env:"KROMGO_QUERY_TIMEOUT" envDefault:"30s"`
 }
 
 // LoadServer reads ServerConfig from the environment.

--- a/internal/logging/logging.go
+++ b/internal/logging/logging.go
@@ -10,10 +10,10 @@ import (
 	"strings"
 )
 
-// Init configures the default slog logger from LOG_LEVEL (debug/info/warn/error,
-// default info) and LOG_FORMAT (text or json, default json).
+// Init configures the default slog logger from KROMGO_LOG_LEVEL (debug/info/warn/error,
+// default info) and KROMGO_LOG_FORMAT (text or json, default json).
 func Init() {
-	slog.SetDefault(slog.New(newHandler(os.Stdout, os.Getenv("LOG_LEVEL"), os.Getenv("LOG_FORMAT"))))
+	slog.SetDefault(slog.New(newHandler(os.Stdout, os.Getenv("KROMGO_LOG_LEVEL"), os.Getenv("KROMGO_LOG_FORMAT"))))
 }
 
 // newHandler builds a JSON (default) or text slog handler at the given level.

--- a/test/e2e/harness.go
+++ b/test/e2e/harness.go
@@ -67,10 +67,10 @@ func start(t *testing.T) *harness {
 	ctx, cancel := context.WithCancel(context.Background())
 	cmd := exec.CommandContext(ctx, bin, "-config", configPath)
 	cmd.Env = append(os.Environ(),
-		"PROMETHEUS_URL="+prom.URL,
-		fmt.Sprintf("SERVER_PORT=%d", serverPort),
-		fmt.Sprintf("METRICS_PORT=%d", metricsPort),
-		"LOG_FORMAT=text",
+		"KROMGO_PROMETHEUS_URL="+prom.URL,
+		fmt.Sprintf("KROMGO_SERVER_PORT=%d", serverPort),
+		fmt.Sprintf("KROMGO_METRICS_PORT=%d", metricsPort),
+		"KROMGO_LOG_FORMAT=text",
 	)
 	cmd.Stdout = os.Stderr
 	cmd.Stderr = os.Stderr

--- a/test/integration/gallery_test.go
+++ b/test/integration/gallery_test.go
@@ -50,13 +50,13 @@ var graphExamples = []struct{ id, title, query string }{
 // handler and writes a self-contained, Tailwind-styled HTML page — each item shown
 // with the kromgo config that produced it. Run:
 //
-//	PROMETHEUS_URL=https://prom.example mise run gallery   # then open kromgo-gallery.html
+//	KROMGO_PROMETHEUS_URL=https://prom.example mise run gallery   # then open kromgo-gallery.html
 //
 // Queries are synthetic (vector()/time()), so it works against any Prometheus.
 func TestGallery(t *testing.T) {
-	url := os.Getenv("PROMETHEUS_URL")
+	url := os.Getenv("KROMGO_PROMETHEUS_URL")
 	if url == "" {
-		t.Skip("PROMETHEUS_URL not set")
+		t.Skip("KROMGO_PROMETHEUS_URL not set")
 	}
 	client, err := prometheus.New(url, 30*time.Second)
 	require.NoError(t, err)

--- a/test/integration/integration_test.go
+++ b/test/integration/integration_test.go
@@ -1,10 +1,10 @@
 //go:build integration
 
 // Package integration exercises kromgo against a real Prometheus.
-// It is skipped unless PROMETHEUS_URL is set, mirroring the org's env-gated
+// It is skipped unless KROMGO_PROMETHEUS_URL is set, mirroring the org's env-gated
 // integration pattern. Run with:
 //
-//	PROMETHEUS_URL=http://localhost:9090 go test -tags integration ./test/integration/...
+//	KROMGO_PROMETHEUS_URL=http://localhost:9090 go test -tags integration ./test/integration/...
 package integration
 
 import (
@@ -23,9 +23,9 @@ import (
 
 func newHandler(t *testing.T) *kromgo.Handler {
 	t.Helper()
-	url := os.Getenv("PROMETHEUS_URL")
+	url := os.Getenv("KROMGO_PROMETHEUS_URL")
 	if url == "" {
-		t.Skip("PROMETHEUS_URL not set; skipping integration test")
+		t.Skip("KROMGO_PROMETHEUS_URL not set; skipping integration test")
 	}
 
 	client, err := prometheus.New(url, 30*time.Second)


### PR DESCRIPTION
Stacked on #285 (branch-based; merge #285 first — this retargets/rebases after).

kromgo was the org's one unprefixed app. Every runtime env var now carries `KROMGO_`, matching echo (`ECHO_*`)/chaski (`CHASKI_*`) conventions:

`SERVER_HOST/PORT`, `METRICS_ENABLED/HOST/PORT`, `SERVER_READ_TIMEOUT/WRITE_TIMEOUT/LOGGING`, `QUERY_TIMEOUT`, `LOG_LEVEL`, `LOG_FORMAT`, `PROMETHEUS_URL` → `KROMGO_*`.

**Compatibility nicety:** the chart Secret key stays `PROMETHEUS_URL` — the deployment injects it via `envFrom` **`prefix: KROMGO_`**, so chart-managed *and* `existingSecret` Secrets keep working with no key rename.

**Breaking:** env vars set outside the chart (`server.extraEnv`, `docker run -e`) must be renamed.

Verified: `go build`, `go test -race`, tagged e2e suite, `helm unittest` 17/17, `helm lint`, golangci-lint, docs/schema regenerated.
