### PR TITLE
feat!: drop the legacy /-/health and /-/ready aliases

### DIFF
--- a/internal/server/health.go
+++ b/internal/server/health.go
@@ -8,9 +8,8 @@ import (
 
 // healthPaths are the liveness/readiness endpoints, served on the MAIN port
 // (the org pair standard: /healthz = liveness, /readyz = readiness — aliases
-// here, kromgo has no serving condition beyond being up). The /-/ variants are
-// kept for backward compatibility.
-var healthPaths = []string{"/healthz", "/readyz", "/-/health", "/-/ready"}
+// here, kromgo has no serving condition beyond being up).
+var healthPaths = []string{"/healthz", "/readyz"}
 
 // withHealth overlays the health endpoints onto the application handler, so
 // probes work regardless of whether the optional metrics listener is enabled.

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -38,7 +38,7 @@ func TestWithHealth(t *testing.T) {
 		appHit = true
 		w.WriteHeader(http.StatusOK)
 	}))
-	for _, path := range []string{"/healthz", "/readyz", "/-/health", "/-/ready"} {
+	for _, path := range []string{"/healthz", "/readyz"} {
 		t.Run(path, func(t *testing.T) {
 			req := httptest.NewRequest(http.MethodGet, path, nil)
 			w := httptest.NewRecorder()


### PR DESCRIPTION
Follow-up to #285 per review: no legacy health paths. `/healthz` + `/readyz` are the only health endpoints; the `/-/` variants predate the port standard and nothing in-chart references them. External probes using them (if any) must move to the pair. Verified: go tests + tagged e2e green.