### PR TITLE
feat: add configurable favicon (GET /favicon.ico)

### DIFF
--- a/README.md
+++ b/README.md
@@ -474,6 +474,21 @@ badges:
 
 When nothing is visible the gallery shows a short hint instead.
 
+## Favicon
+
+kromgo is self-contained (see [Gallery](#gallery) above) and ships no default favicon, so
+`GET /favicon.ico` 404s unless you configure one. Set a top-level `favicon` to a base64-encoded PNG,
+GIF, or ICO image and kromgo serves it at `/favicon.ico` and links it from both the gallery and the
+landing page:
+
+```yaml
+favicon: iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII=
+```
+
+The Content-Type is detected from the decoded bytes, so no separate `favicon` MIME/format field is
+needed — an unsupported or malformed value fails at startup like any other config error (see
+[Configuration](#configuration)).
+
 ## API reference
 
 | Route              | Default response        | Variants                                                           |
@@ -482,6 +497,7 @@ When nothing is visible the gallery shows a short hint instead.
 | `GET /graphs/{id}` | SVG chart (`?theme=…`)  | `?format=png` → PNG image · `?format=json` → time-series data      |
 | `GET /`            | HTML gallery            | landing page when `gallery.enabled: false`                         |
 | `GET /assets/…`    | Embedded gallery JS/CSS |                                                                    |
+| `GET /favicon.ico` | The configured favicon  | 404 when `favicon` is unset (see [Favicon](#favicon))               |
 
 **`/badges/{id}`** (default SVG):
 

--- a/charts/kromgo/README.md
+++ b/charts/kromgo/README.md
@@ -45,6 +45,7 @@ Kubernetes: `>=1.25.0-0`
 | config.cache.enabled | bool | `true` | Send Cache-Control headers on badge/graph responses. |
 | config.cache.maxAge | int | `300` | max-age + s-maxage in seconds (ignored when cache is disabled). |
 | config.defaults | object | `{}` | Defaults applied to every endpoint, each overridable per badge/graph. |
+| config.favicon | string | `""` | Base64-encoded PNG/GIF/ICO image served at GET /favicon.ico. Empty (default) serves no favicon. |
 | config.gallery.enabled | bool | `true` | Preview every endpoint at "/" with copy-paste Markdown; false serves a minimal landing page. |
 | config.graphs | list | `[]` | Time-series endpoints served at /graphs/{id}. |
 | config.prometheus | string | `"http://prometheus-operated.monitoring.svc.cluster.local:9090"` | Prometheus base URL kromgo queries; use `secret.prometheusUrl` instead when it embeds credentials. |

--- a/charts/kromgo/values.schema.json
+++ b/charts/kromgo/values.schema.json
@@ -44,6 +44,12 @@
           "title": "defaults",
           "type": "object"
         },
+        "favicon": {
+          "default": "",
+          "description": "Base64-encoded PNG/GIF/ICO image served at GET /favicon.ico. Empty (default) serves no favicon.",
+          "title": "favicon",
+          "type": "string"
+        },
         "gallery": {
           "description": "The \"/\" gallery previews every endpoint with copy-paste Markdown. Defaults to\nenabled; set false to serve a minimal landing page instead.",
           "properties": {

--- a/charts/kromgo/values.yaml
+++ b/charts/kromgo/values.yaml
@@ -62,6 +62,9 @@ config:
     # -- Preview every endpoint at "/" with copy-paste Markdown; false serves a minimal landing page.
     enabled: true
 
+  # -- Base64-encoded PNG/GIF/ICO image served at GET /favicon.ico. Empty (default) serves no favicon.
+  favicon: ""
+
   # Cache-Control headers sent with badge/graph responses. One policy applies to
   # every endpoint.
   cache:

--- a/config.schema.json
+++ b/config.schema.json
@@ -231,6 +231,9 @@
             "$ref": "#/$defs/Graph"
           },
           "type": "array"
+        },
+        "favicon": {
+          "type": "string"
         }
       },
       "additionalProperties": false,

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -3,7 +3,9 @@
 package config
 
 import (
+	"encoding/base64"
 	"fmt"
+	"net/http"
 	"os"
 	"regexp"
 
@@ -23,6 +25,36 @@ type KromgoConfig struct {
 	Defaults   Defaults `yaml:"defaults,omitempty" json:"defaults,omitempty"`
 	Badges     []Badge  `yaml:"badges,omitempty" json:"badges,omitempty"`
 	Graphs     []Graph  `yaml:"graphs,omitempty" json:"graphs,omitempty"`
+	// Favicon is base64-encoded image data served at GET /favicon.ico. Accepts PNG,
+	// GIF, or ICO bytes — the Content-Type is detected from the decoded data, the
+	// same way the standard library sniffs an upload. Empty (default) serves no
+	// favicon; the route falls through to kromgo's normal 404.
+	Favicon string `yaml:"favicon,omitempty" json:"favicon,omitempty"`
+}
+
+// validFaviconTypes are the Content-Types DecodeFavicon accepts, as detected by
+// http.DetectContentType — the image formats browsers actually request as a favicon.
+var validFaviconTypes = map[string]bool{
+	"image/png":    true,
+	"image/x-icon": true,
+	"image/gif":    true,
+}
+
+// DecodeFavicon decodes and validates Favicon, returning the decoded bytes and
+// detected Content-Type. Returns a nil slice and empty string when Favicon is unset.
+func (c KromgoConfig) DecodeFavicon() ([]byte, string, error) {
+	if c.Favicon == "" {
+		return nil, "", nil
+	}
+	data, err := base64.StdEncoding.DecodeString(c.Favicon)
+	if err != nil {
+		return nil, "", fmt.Errorf("favicon: invalid base64: %w", err)
+	}
+	contentType := http.DetectContentType(data)
+	if !validFaviconTypes[contentType] {
+		return nil, "", fmt.Errorf("favicon: unsupported content type %q (want a PNG, GIF, or ICO image)", contentType)
+	}
+	return data, contentType, nil
 }
 
 // Cache configures the Cache-Control headers kromgo sends with badge and graph
@@ -275,6 +307,9 @@ func (c KromgoConfig) validate() error {
 	}
 	if s := c.Defaults.Badge.Style; s != "" && !ValidStyle[s] {
 		return fmt.Errorf("defaults.badge.style: unknown style %q", s)
+	}
+	if _, _, err := c.DecodeFavicon(); err != nil {
+		return err
 	}
 	if err := validateEndpoints(c.Badges, "badge"); err != nil {
 		return err

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -129,6 +129,43 @@ func TestLoad_Style(t *testing.T) {
 	assert.Contains(t, err.Error(), "unknown style")
 }
 
+func TestLoad_Favicon(t *testing.T) {
+	t.Parallel()
+
+	// A 1x1 transparent PNG, base64-encoded.
+	const pngB64 = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII="
+
+	cfg, err := Load(writeConfig(t, "favicon: "+pngB64+"\n"))
+	require.NoError(t, err)
+	data, contentType, err := cfg.DecodeFavicon()
+	require.NoError(t, err)
+	assert.Equal(t, "image/png", contentType)
+	assert.NotEmpty(t, data)
+
+	// Unset favicon decodes to nothing, no error.
+	cfg, err = Load(writeConfig(t, "badges: []\n"))
+	require.NoError(t, err)
+	data, contentType, err = cfg.DecodeFavicon()
+	require.NoError(t, err)
+	assert.Empty(t, contentType)
+	assert.Nil(t, data)
+}
+
+func TestLoad_FaviconInvalidBase64(t *testing.T) {
+	t.Parallel()
+	_, err := Load(writeConfig(t, "favicon: not-valid-base64!!!\n"))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "favicon")
+}
+
+func TestLoad_FaviconUnsupportedType(t *testing.T) {
+	t.Parallel()
+	// Plain text decodes fine as base64 but isn't a supported image type.
+	_, err := Load(writeConfig(t, "favicon: aGVsbG8gd29ybGQ=\n"))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unsupported content type")
+}
+
 func TestLoadServer_Defaults(t *testing.T) {
 	// Clear any inherited env so envDefault applies. t.Setenv registers the
 	// restore; os.Unsetenv then removes the var for the duration of the test.

--- a/internal/kromgo/handler.go
+++ b/internal/kromgo/handler.go
@@ -20,12 +20,14 @@ const (
 
 // Handler serves badge and graph endpoints backed by Prometheus queries.
 type Handler struct {
-	cfg    config.KromgoConfig
-	cache  cachePolicy
-	badges map[string]*resolvedBadge
-	graphs map[string]*resolvedGraph
-	prom   *prometheus.Client
-	gen    *badgeRenderer
+	cfg         config.KromgoConfig
+	cache       cachePolicy
+	badges      map[string]*resolvedBadge
+	graphs      map[string]*resolvedGraph
+	prom        *prometheus.Client
+	gen         *badgeRenderer
+	faviconData []byte
+	faviconType string
 }
 
 // New builds a Handler from config and a Prometheus client. Per-endpoint CEL
@@ -33,6 +35,11 @@ type Handler struct {
 // at startup rather than on a request.
 func New(cfg config.KromgoConfig, prom *prometheus.Client) (*Handler, error) {
 	gen, err := newBadgeRenderer(cfg.Defaults.Badge)
+	if err != nil {
+		return nil, err
+	}
+
+	faviconData, faviconType, err := cfg.DecodeFavicon()
 	if err != nil {
 		return nil, err
 	}
@@ -60,7 +67,10 @@ func New(cfg config.KromgoConfig, prom *prometheus.Client) (*Handler, error) {
 		graphs[g.ID] = rg
 	}
 
-	return &Handler{cfg: cfg, cache: resolveCache(cfg.Cache), badges: badges, graphs: graphs, prom: prom, gen: gen}, nil
+	return &Handler{
+		cfg: cfg, cache: resolveCache(cfg.Cache), badges: badges, graphs: graphs, prom: prom, gen: gen,
+		faviconData: faviconData, faviconType: faviconType,
+	}, nil
 }
 
 // Mux returns the application router: the index page and per-type endpoints.
@@ -68,6 +78,9 @@ func (h *Handler) Mux() http.Handler {
 	mux := http.NewServeMux()
 	mux.HandleFunc("GET /{$}", h.index)
 	mux.Handle("GET /assets/", assetsHandler())
+	if len(h.faviconData) > 0 {
+		mux.HandleFunc("GET /favicon.ico", h.favicon)
+	}
 	mux.HandleFunc("GET /badges/{id}", h.serveBadge)
 	mux.HandleFunc("GET /graphs/{id}", h.serveGraph)
 	return mux

--- a/internal/kromgo/handler_test.go
+++ b/internal/kromgo/handler_test.go
@@ -403,3 +403,43 @@ func TestAssetsRoute(t *testing.T) {
 	assert.Equal(t, http.StatusOK, w.Code)
 	assert.Contains(t, w.Header().Get("Content-Type"), "javascript")
 }
+
+// A 1x1 transparent PNG, base64-encoded.
+const testFaviconPNG = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII="
+
+func TestFaviconRoute(t *testing.T) {
+	t.Parallel()
+	cfg := baseConfig()
+	cfg.Favicon = testFaviconPNG
+	srv := mockProm(t, "0", nil)
+	h := newHandlerForTest(t, cfg, srv.URL)
+
+	w := promtest.Get(t, h.Mux(), "/favicon.ico")
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, "image/png", w.Header().Get("Content-Type"))
+	assert.Contains(t, w.Header().Get("Cache-Control"), "max-age=")
+	assert.NotEmpty(t, w.Body.Bytes())
+}
+
+func TestFaviconRoute_UnsetIs404(t *testing.T) {
+	t.Parallel()
+	srv := mockProm(t, "0", nil)
+	h := newHandlerForTest(t, baseConfig(), srv.URL) // no Favicon configured
+
+	w := promtest.Get(t, h.Mux(), "/favicon.ico")
+
+	assert.Equal(t, http.StatusNotFound, w.Code)
+}
+
+func TestNew_InvalidFaviconFailsFast(t *testing.T) {
+	t.Parallel()
+	cfg := baseConfig()
+	cfg.Favicon = "not-valid-base64!!!"
+	srv := mockProm(t, "1", nil)
+	client, err := prometheus.New(srv.URL, 0)
+	require.NoError(t, err)
+
+	_, err = New(cfg, client)
+	assert.Error(t, err)
+}

--- a/internal/kromgo/index.go
+++ b/internal/kromgo/index.go
@@ -41,6 +41,9 @@ var galleryTmpl = template.Must(template.New("gallery").Parse(`<!DOCTYPE html>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>kromgo</title>
+{{- if .HasFavicon}}
+<link rel="icon" href="/favicon.ico">
+{{- end}}
 <link rel="stylesheet" href="/assets/github-markdown.css">
 <link rel="stylesheet" href="/assets/gallery.css">
 </head>
@@ -79,6 +82,9 @@ var landingTmpl = template.Must(template.New("landing").Parse(`<!DOCTYPE html>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>kromgo</title>
+{{- if .HasFavicon}}
+<link rel="icon" href="/favicon.ico">
+{{- end}}
 <link rel="stylesheet" href="/assets/gallery.css">
 </head>
 <body>
@@ -94,8 +100,15 @@ var landingTmpl = template.Must(template.New("landing").Parse(`<!DOCTYPE html>
 // galleryView is the gallery template's data: visible badges and graphs as
 // copy-pasteable Markdown snippets, badges first.
 type galleryView struct {
-	Badges []galleryItem
-	Graphs []galleryItem
+	HasFavicon bool
+	Badges     []galleryItem
+	Graphs     []galleryItem
+}
+
+// landingView is the minimal landing template's data (used when gallery.enabled
+// is false).
+type landingView struct {
+	HasFavicon bool
 }
 
 // galleryItem is one endpoint rendered as a Markdown image snippet.
@@ -114,12 +127,13 @@ func (h *Handler) index(w http.ResponseWriter, r *http.Request) {
 	header.Set("Cache-Control", "no-store")
 
 	if !firstSet(true, h.cfg.Gallery.Enabled) {
-		_ = landingTmpl.Execute(w, nil)
+		_ = landingTmpl.Execute(w, landingView{HasFavicon: len(h.faviconData) > 0})
 		return
 	}
 
 	base := baseURL(r)
 	view := galleryView{
+		HasFavicon: len(h.faviconData) > 0,
 		Badges: galleryItems(base, "badges", h.cfg.Badges, h.cfg.Defaults.Badge.Gallery.Hidden,
 			func(b config.Badge) (string, string, *bool) {
 				return b.ID, displayTitle(b.Title, b.ID), b.Gallery.Hidden
@@ -158,6 +172,15 @@ func assetsHandler() http.Handler {
 		w.Header().Set("Cache-Control", "public, max-age=3600")
 		fileServer.ServeHTTP(w, r)
 	}))
+}
+
+// favicon serves the configured Favicon at GET /favicon.ico. Mux only registers
+// this route when Favicon is set, so this is never reached otherwise. Cached
+// like /assets/: it only changes when the binary restarts with new config.
+func (h *Handler) favicon(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", h.faviconType)
+	w.Header().Set("Cache-Control", "public, max-age=3600")
+	_, _ = w.Write(h.faviconData)
 }
 
 // markdownItem builds a Markdown image snippet for an endpoint, e.g.

--- a/internal/kromgo/index_test.go
+++ b/internal/kromgo/index_test.go
@@ -189,6 +189,28 @@ func TestIndexHandler_NoEndpoints_ShowsEmptyState(t *testing.T) {
 	assert.Contains(t, body, "No endpoints to show")
 }
 
+func TestIndexHandler_FaviconLink(t *testing.T) {
+	t.Parallel()
+
+	withoutFavicon := newTestHandler(config.KromgoConfig{Badges: []config.Badge{{ID: "cpu"}}})
+	assert.NotContains(t, getIndex(withoutFavicon).Body.String(), `rel="icon"`)
+
+	withFavicon := newTestHandler(config.KromgoConfig{Badges: []config.Badge{{ID: "cpu"}}})
+	withFavicon.faviconData = []byte("fake-icon-bytes")
+	assert.Contains(t, getIndex(withFavicon).Body.String(), `<link rel="icon" href="/favicon.ico">`)
+}
+
+func TestIndexHandler_GalleryDisabled_FaviconLink(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHandler(config.KromgoConfig{Gallery: config.Gallery{Enabled: new(false)}})
+	h.faviconData = []byte("fake-icon-bytes")
+	body := getIndex(h).Body.String()
+
+	assert.Contains(t, body, `class="landing"`)
+	assert.Contains(t, body, `<link rel="icon" href="/favicon.ico">`)
+}
+
 func TestIndexHandler_GalleryDisabled_ShowsLanding(t *testing.T) {
 	t.Parallel()
 	h := newTestHandler(config.KromgoConfig{


### PR DESCRIPTION
## Summary

kromgo is a self-contained binary with no way to customize its branding, so `GET /favicon.ico` always 404s regardless of config — every deployment shows a bare browser tab.

- Adds a top-level `favicon` config key: base64-encoded PNG/GIF/ICO image data, decoded and validated at startup — a bad value fails fast in `config.Load`, the same way every other config error does, rather than surfacing on first request.
- When set, kromgo serves it at `GET /favicon.ico` (Content-Type detected via `http.DetectContentType`, `Cache-Control` akin to `/assets/`) and links it from both the gallery and landing page `<head>`.
- Left unset, behavior is unchanged: the route isn't registered on the mux and falls through to the normal 404.
- Regenerated `config.schema.json`, `charts/kromgo/values.schema.json`, and `charts/kromgo/README.md` (`mise run generate`); added a documented `config.favicon` default to `charts/kromgo/values.yaml`.
- Documented in `README.md` under a new "Favicon" section, and added a row to the API reference table.

## Test plan

- [x] `mise run assets && go build ./...`
- [x] `go vet ./...`
- [x] `golangci-lint run` — 0 issues
- [x] `go test $(go list ./...) -coverprofile cover.out` — all packages pass (93.1% config, 92.0% kromgo)
- [x] `go test -tags e2e ./test/e2e/...` — all scenarios pass
- [x] `helm lint charts/kromgo`
- [x] `helm unittest charts/kromgo` — 17/17 tests pass
- [x] `mise run generate` — no stale generated files
- [ ] Maintainer call: is base64-inline the right shape for this, vs. e.g. a file path / existing-ConfigMap-style option? Went with inline base64 since it mirrors how the Helm chart already renders `config` verbatim into a ConfigMap (so `--set-file` or a values-file blob works naturally), and needs no extra volume/mount plumbing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)