### PR TITLE
fix(helm): stamp Chart.yaml version on release

### DIFF
--- a/.mise/config.toml
+++ b/.mise/config.toml
@@ -109,8 +109,7 @@ run = "helm unittest charts/kromgo"
 description = "Install the chart into the current cluster (e.g. a kind context) and run `helm test`"
 # The e2e workflow builds the PR's image, kind-loads it, and sets
 # KROMGO_TEST_IMAGE_TAG=e2e + pull policy Never so the test runs the code under
-# review; locally these default to the published `latest` for a quick chart check
-# (the chart appVersion is a release-time placeholder, so a tag is always needed).
+# review; locally these default to the published `latest` for a quick chart check.
 # config.prometheus is never dialed at startup and /readyz is static, so the pod
 # becomes Ready without a real Prometheus.
 run = """

--- a/charts/kromgo/Chart.yaml
+++ b/charts/kromgo/Chart.yaml
@@ -6,9 +6,10 @@ type: application
 # Floor matching the chart's surface: restricted Pod Security (seccompProfile),
 # networking.k8s.io/v1 Ingress, and the Gateway API v1 HTTPRoute.
 kubeVersion: ">=1.25.0-0"
-# version + appVersion are overridden at package time from the release tag.
-version: 0.0.0
-appVersion: "0.0.0"
+# release-please stamps both on release; the release workflow re-stamps them at
+# package time from the tag anyway, so this keeps the repo copy from going stale.
+version: 0.15.1 # x-release-please-version
+appVersion: "0.15.1" # x-release-please-version
 home: https://github.com/home-operations/kromgo
 sources:
   - https://github.com/home-operations/kromgo

--- a/charts/kromgo/README.md
+++ b/charts/kromgo/README.md
@@ -1,6 +1,8 @@
 # kromgo
 
-![Version: 0.0.0](https://img.shields.io/badge/Version-0.0.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.0.0](https://img.shields.io/badge/AppVersion-0.0.0-informational?style=flat-square)
+![Version](https://img.shields.io/static/v1?label=Version&message=0.15.1&color=informational&style=flat-square) <!-- x-release-please-version -->
+![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![AppVersion](https://img.shields.io/static/v1?label=AppVersion&message=0.15.1&color=informational&style=flat-square) <!-- x-release-please-version -->
 
 Safely expose individual Prometheus metric values as SVG badges and graphs
 

--- a/charts/kromgo/README.md.gotmpl
+++ b/charts/kromgo/README.md.gotmpl
@@ -1,6 +1,14 @@
 {{ template "chart.header" . }}
 
-{{ template "chart.badgesSection" . }}
+{{- /* Hand-rolled badges instead of chart.badgesSection so release-please can
+stamp the version: its updater replaces only the first semver on an annotated
+line and would swallow a `-color` suffix as a prerelease, so each version badge
+uses the static/v1 query form (version followed by `&`), keeps the version out
+of its alt text, and carries its own annotation. Keeps the committed README in
+sync with the stamped Chart.yaml. */}}
+![Version](https://img.shields.io/static/v1?label=Version&message={{ .Version }}&color=informational&style=flat-square) <!-- x-release-please-version -->
+![Type: {{ .Type }}](https://img.shields.io/badge/Type-{{ .Type }}-informational?style=flat-square)
+![AppVersion](https://img.shields.io/static/v1?label=AppVersion&message={{ .AppVersion }}&color=informational&style=flat-square) <!-- x-release-please-version -->
 
 {{ template "chart.description" . }}
 

--- a/charts/kromgo/tests/deployment_test.yaml
+++ b/charts/kromgo/tests/deployment_test.yaml
@@ -5,12 +5,14 @@ templates:
   - deployment.tpl
   - configmap.tpl
 tests:
+  # The tag floats with the release-please-stamped appVersion; assert the
+  # repo:semver shape rather than a hardcoded version.
   - it: defaults the image to repository:appVersion when no digest or tag is set
     template: deployment.tpl
     asserts:
-      - equal:
+      - matchRegex:
           path: spec.template.spec.containers[0].image
-          value: ghcr.io/home-operations/kromgo:0.0.0
+          pattern: ^ghcr\.io/home-operations/kromgo:\d+\.\d+\.\d+$
 
   - it: prefers the digest over the tag when set
     template: deployment.tpl

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -11,7 +11,11 @@
       "include-component-in-tag": false,
       "include-v-in-tag": false,
       "include-v-in-release-name": false,
-      "always-update": true
+      "always-update": true,
+      "extra-files": [
+        { "type": "generic", "path": "charts/kromgo/Chart.yaml" },
+        "charts/kromgo/README.md"
+      ]
     }
   },
   "changelog-sections": [


### PR DESCRIPTION
`charts/kromgo/Chart.yaml` carried a `0.0.0` placeholder for `version` and `appVersion`, so the committed chart (and the helm-docs badges generated from it) never reflected a real release. Only `helm package --version/--app-version` in the release workflow produced a versioned chart.

release-please now stamps both fields, seeded from the current released version in `.release-please-manifest.json` (`0.15.1`). The release workflow still re-stamps at package time from the tag, so this is purely about keeping the repo copy from going stale.

### Why the typed `generic` updater

`extra-files` uses the typed form for the chart manifest:

```json
"extra-files": [
  { "type": "generic", "path": "charts/kromgo/Chart.yaml" },
  "charts/kromgo/README.md"
]
```

release-please picks an updater from the file extension when given a bare string, so a plain `"charts/kromgo/Chart.yaml"` selects the YAML updater, which re-serializes the document (stripping every comment in the file, including the `kubeVersion` rationale) and does not stamp `appVersion` at all. The generic updater edits only the `# x-release-please-version`-annotated lines in place.

### Badge consequence

`chart.badgesSection` emits all three badges on one line and embeds the version in both the alt text and a `-informational` shields path segment. The generic updater rewrites only the first semver on an annotated line and would read the `-color` suffix as a prerelease, so `README.md.gotmpl` hand-rolls the badges: one per line, `static/v1` query form (version followed by `&`), version kept out of the alt text, each with its own annotation. The comment in the template documents that constraint.

### Test consequence

`charts/kromgo/tests/deployment_test.yaml` pinned the default image to `ghcr.io/home-operations/kromgo:0.0.0`. The tag now floats with the stamped `appVersion`, so that assertion became a `matchRegex` on the `repo:semver` shape. Other `0.0.0` hits in the repo were checked and are unrelated (`go.mod`/`go.sum` pseudo-versions, the `package.json` placeholder, and an unspecified-address comment). Also drops the now-false note on the `helm-test` mise task claiming the chart `appVersion` is a release-time placeholder.

Ports home-operations/tuppr#414 and home-operations/tuppr#415.

## Verification

| Gate | Result |
| --- | --- |
| `mise run helm-lint` | pass (1 chart linted, 0 failed; only the pre-existing `icon is recommended` INFO) |
| `mise run helm-unittest` | pass (1 chart, 5 suites, 17 tests) |
| `mise run generate-check` | pass (clean `git diff` for `config.schema.json`, `charts/kromgo/README.md`, `charts/kromgo/values.schema.json`) |
| `mise run helm-template` | renders `helm.sh/chart: kromgo-0.15.1` / `app.kubernetes.io/version: "0.15.1"` |
| `helm package --version 9.9.9 --app-version 9.9.9` | packaged chart reports `9.9.9` for both, confirming the release workflow's package-time stamp still overrides the committed values |
| lefthook pre-commit | pass (`format-json`, `format-yaml`, `format-mise`, `generate`, `mise-lock` all clean; no `mise.lock` drift) |

Go suites were not run: this change is chart, docs, and release-config only.
