### PR TITLE
ci: lint workflows with the shared composite action

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -265,6 +265,37 @@ jobs:
           helm plugin install https://github.com/helm-unittest/helm-unittest --version "${HELM_UNITTEST_VERSION}" --verify=false
           mise run helm-unittest
 
+  workflow-lint:
+    if: >-
+      ${{ !(startsWith(github.head_ref, 'release-please--')
+      && github.event.pull_request.head.repo.full_name == github.repository) }}
+    name: Workflow Lint
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Setup Mise
+        uses: jdx/mise-action@dad1bfd3df957f44999b559dd69dc1671cb4e9ea # v4.2.1
+        with:
+          install: false
+
+      - name: Resolve linter versions
+        id: tools
+        run: |
+          echo "actionlint=$(mise config get tools.actionlint)" >> "$GITHUB_OUTPUT"
+          echo "zizmor=$(mise config get tools.zizmor)" >> "$GITHUB_OUTPUT"
+
+      - name: Lint workflows
+        uses: home-operations/.github/actions/workflow-lint@dfa0b198336d33dcbe73557a68315d3071ec7709 # workflow-lint-1.0.0
+        with:
+          actionlint-version: ${ steps.tools.outputs.actionlint }
+          zizmor-version: ${ steps.tools.outputs.zizmor }
+
   status:
     if: ${{ !cancelled() }}
     name: Build Success
@@ -275,6 +306,7 @@ jobs:
       - helm-e2e
       - helm-lint
       - helm-unittest
+      - workflow-lint
     runs-on: ubuntu-24.04
     permissions: {}
     steps:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -293,8 +293,8 @@ jobs:
       - name: Lint workflows
         uses: home-operations/.github/actions/workflow-lint@dfa0b198336d33dcbe73557a68315d3071ec7709 # workflow-lint-1.0.0
         with:
-          actionlint-version: ${ steps.tools.outputs.actionlint }
-          zizmor-version: ${ steps.tools.outputs.zizmor }
+          actionlint-version: ${{ steps.tools.outputs.actionlint }}
+          zizmor-version: ${{ steps.tools.outputs.zizmor }}
 
   status:
     if: ${{ !cancelled() }}


### PR DESCRIPTION
Adds `home-operations/.github/actions/workflow-lint`, pinned to `workflow-lint-1.0.0`.

The action defaults both linters to `latest`; this job instead reads them out of `.mise/config.toml` with `mise config get` and passes them in, so CI runs the same actionlint and zizmor builds as the pre-commit hooks here.

Same job already merged in echo, tuppr, miroir and kopiur.