### PR TITLE
chore: standardize release-please changelog sections

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,7 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
   "release-type": "simple",
-  "exclude-paths": ["release-please-config.json", ".release-please-manifest.json"],
   "packages": {
     ".": {
       "changelog-path": "CHANGELOG.md",
@@ -13,7 +12,10 @@
       "include-v-in-release-name": false,
       "always-update": true,
       "extra-files": [
-        { "type": "generic", "path": "charts/kromgo/Chart.yaml" },
+        {
+          "type": "generic",
+          "path": "charts/kromgo/Chart.yaml"
+        },
         "charts/kromgo/README.md"
       ]
     }
@@ -21,63 +23,51 @@
   "changelog-sections": [
     {
       "type": "feat",
-      "section": "Features",
-      "hidden": false
+      "section": "Features"
     },
     {
       "type": "fix",
-      "section": "Bug Fixes",
-      "hidden": false
+      "section": "Bug Fixes"
     },
     {
       "type": "perf",
-      "section": "Performance Improvements",
-      "hidden": false
-    },
-    {
-      "type": "revert",
-      "section": "Reverts",
-      "hidden": false
-    },
-    {
-      "type": "docs",
-      "section": "Documentation",
-      "hidden": false
-    },
-    {
-      "type": "style",
-      "section": "Styles",
-      "hidden": false
-    },
-    {
-      "type": "chore",
-      "section": "Miscellaneous Chores",
-      "hidden": false
+      "section": "Performance Improvements"
     },
     {
       "type": "refactor",
-      "section": "Code Refactoring",
-      "hidden": false
+      "section": "Code Refactoring"
+    },
+    {
+      "type": "revert",
+      "section": "Reverts"
+    },
+    {
+      "type": "docs",
+      "section": "Documentation"
+    },
+    {
+      "type": "style",
+      "section": "Styles"
     },
     {
       "type": "test",
-      "section": "Tests",
-      "hidden": true
+      "section": "Tests"
     },
     {
       "type": "build",
-      "section": "Build System",
-      "hidden": true
+      "section": "Build System"
     },
     {
       "type": "ci",
-      "section": "Continuous Integration",
-      "hidden": true
+      "section": "Continuous Integration"
+    },
+    {
+      "type": "chore",
+      "section": "Miscellaneous Chores"
     },
     {
       "type": "deps",
-      "section": "Dependencies",
-      "hidden": true
+      "section": "Dependencies"
     }
   ]
 }


### PR DESCRIPTION
Standardizes the release-please changelog configuration across home-operations repos:

- `changelog-sections`: one section per commit type, all types visible, fixed order (Features → Bug Fixes → Performance Improvements → Code Refactoring → Reverts → Documentation → Styles → Tests → Build System → Continuous Integration → Miscellaneous Chores → Dependencies)
- removes `exclude-paths` entries that only listed release-please's own config files

No changes to version bumping, tagging, or release behavior.
