### PR TITLE
chore(release-please): standardize the release pull request title pattern

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
   "release-type": "simple",
+  "pull-request-title-pattern": "chore(release):${component} ${version}",
   "packages": {
     ".": {
       "changelog-path": "CHANGELOG.md",


### PR DESCRIPTION
## Overview

Adds `pull-request-title-pattern` so that every repository's release pull request title starts with `chore(release):`.

The merge queue only exposes the squashed commit message. `github.head_ref` is empty on a `merge_group` event, so the existing `startsWith(github.head_ref, 'release-please--')` guard in `ci.yaml` never matches there: a release pull request skips the heavy jobs on the pull request and then runs the full suite inside the queue. A single anchored prefix gives that guard something to match on.

## Additional information

Titles change from `chore(main): release 0.9.2` to `chore(release): 0.9.2`. Branch names, labels, tags, release names and changelog content are unchanged, and CI behaviour is unchanged until the `merge_group` clause lands in `ci.yaml` as a follow-up.
